### PR TITLE
fix logic to detect is it'a example page

### DIFF
--- a/stanzas/breadcrumbs/index.js
+++ b/stanzas/breadcrumbs/index.js
@@ -57,7 +57,9 @@ function isExamplePage() {
 
   if (
     pageName === stanzaId &&
-    (hostname.includes("metastanza") || hostname.includes("localhost"))
+    (hostname.includes("metastanza") ||
+      hostname.includes("localhost") ||
+      hostname.includes("togostanza"))
   ) {
     return true;
   }


### PR DESCRIPTION
Example page で 親エレメントの `overflow` のcss　修正、ヘルプページであるかどうか、チェックするロジックを修正。