### PR TITLE
Optimize getMarginsFromCSSString of utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -115,22 +115,22 @@ export function getMarginsFromCSSString(str) {
 
   switch (splitted.length) {
     case 1:
-      res.TOP = res.RIGHT = res.BOTTOM = res.LEFT = parseInt(splitted[0]);
+      res.TOP = res.RIGHT = res.BOTTOM = res.LEFT = parseInt(splitted[0]) || 0;
       break;
     case 2:
-      res.TOP = res.BOTTOM = parseInt(splitted[0]);
-      res.LEFT = res.RIGHT = parseInt(splitted[1]);
+      res.TOP = res.BOTTOM = parseInt(splitted[0]) || 0;
+      res.LEFT = res.RIGHT = parseInt(splitted[1]) || 0;
       break;
     case 3:
-      res.TOP = parseInt(splitted[0]);
-      res.LEFT = res.RIGHT = parseInt(splitted[1]);
-      res.BOTTOM = parseInt(splitted[2]);
+      res.TOP = parseInt(splitted[0]) || 0;
+      res.LEFT = res.RIGHT = parseInt(splitted[1]) || 0;
+      res.BOTTOM = parseInt(splitted[2]) || 0;
       break;
     case 4:
-      res.TOP = parseInt(splitted[0]);
-      res.RIGHT = parseInt(splitted[1]);
-      res.BOTTOM = parseInt(splitted[2]);
-      res.LEFT = parseInt(splitted[3]);
+      res.TOP = parseInt(splitted[0]) || 0;
+      res.RIGHT = parseInt(splitted[1]) || 0;
+      res.BOTTOM = parseInt(splitted[2]) || 0;
+      res.LEFT = parseInt(splitted[3]) || 0;
       break;
     default:
       break;


### PR DESCRIPTION
paddingが0の際のNaNになることを防ぐために追記しました。