### PR TITLE
Breadcrumbs Node の幅が変わらないバッグの修正

### DIFF
--- a/stanzas/breadcrumbs/components/BreadcrumbsNode.js
+++ b/stanzas/breadcrumbs/components/BreadcrumbsNode.js
@@ -47,7 +47,19 @@ class Node extends LitElement {
     this.arrowWidth = 2;
   }
 
-  firstUpdated() {
+  willUpdate() {
+    if (!this.svg.value) {
+      this.svg.value = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg"
+      );
+      this.svg.value.setAttribute("width", 0);
+      this.svg.value.setAttribute("height", 0);
+      this.renderRoot.append(this.svg.value);
+    }
+
+    this.icon = FAIcons[`fa${this.iconName}`]?.icon;
+
     let { textWidth, textHeight } = this._getTextRect(this.node.label);
 
     if (textHeight === 0) {
@@ -127,13 +139,13 @@ class Node extends LitElement {
     if (!text) {
       return { textWidth: 0, textHeight: 0 };
     }
-    const svg = this.svg.value;
+
     const textEl = document.createElementNS(
       "http://www.w3.org/2000/svg",
       "text"
     );
 
-    svg.append(textEl);
+    this.svg.value.append(textEl);
 
     textEl.textContent = text;
 
@@ -176,10 +188,6 @@ class Node extends LitElement {
   }
   _handleMenuLeave() {
     this._unhover();
-  }
-
-  willUpdate() {
-    this.icon = FAIcons[`fa${this.iconName}`]?.icon;
   }
 
   render() {


### PR DESCRIPTION
<img width="286" alt="image" src="https://user-images.githubusercontent.com/55772081/208587200-e490fcba-f2b0-47ff-aec1-11451ba571ca.png">
