### PR TITLE
Feature/linechart

### DIFF
--- a/stanzas/linechart/index.js
+++ b/stanzas/linechart/index.js
@@ -46,8 +46,8 @@ export default class Linechart extends Stanza {
     const hideYAxis = !this._validatedParams.get("axis-y-visible").value;
     const hideXAxisTicks = this._validatedParams.get("axis-x-ticks_hide").value;
     const hideYAxisTicks = this._validatedParams.get("axis-y-ticks_hide").value;
-    const showPoints = this._validatedParams.get("points-show").value;
-    const pointsSize = this._validatedParams.get("points-size").value;
+    const pointsSize = this.params["points_size"];
+    const showPoints = pointsSize && !isNaN(parseFloat(pointsSize));
 
     const errorKeyName = this._validatedParams.get("error_bars-key").value;
 
@@ -152,7 +152,10 @@ export default class Linechart extends Stanza {
     }
 
     // Data symbols
-    const symbolGenerator = d3.symbol().size(pointsSize).type(d3.symbolCircle);
+    const symbolGenerator = d3
+      .symbol()
+      .size(() => pointsSize * pointsSize)
+      .type(d3.symbolCircle);
 
     const width = css("--togostanza-outline-width");
     const height = css("--togostanza-outline-height");

--- a/stanzas/linechart/index.js
+++ b/stanzas/linechart/index.js
@@ -42,8 +42,6 @@ export default class Linechart extends Stanza {
     const yKeyName = this._validatedParams.get("axis-y-key").value;
     const xAxisTitle = this._validatedParams.get("axis-x-title").value;
     const yAxisTitle = this._validatedParams.get("axis-y-title").value || "";
-    const hideXAxis = !this._validatedParams.get("axis-x-visible").value;
-    const hideYAxis = !this._validatedParams.get("axis-y-visible").value;
     const hideXAxisTicks = this._validatedParams.get("axis-x-ticks_hide").value;
     const hideYAxisTicks = this._validatedParams.get("axis-y-ticks_hide").value;
     const pointsSize = this.params["points_size"];
@@ -952,11 +950,11 @@ export default class Linechart extends Stanza {
               .call(updateSymbolTranslate.bind(this));
           }
 
-          if (!hideXAxis && !hideXAxisTicks) {
+          if (!hideXAxisTicks) {
             graphXAxisG.call(xAxis).call(rotateXTickLabels);
           }
 
-          if (!hideYAxis && !hideYAxisTicks) {
+          if (!hideYAxisTicks) {
             graphYAxisG.call(yAxis);
           }
         };
@@ -975,11 +973,11 @@ export default class Linechart extends Stanza {
 
           this._scaleY.domain(d3.extent(y0y1));
 
-          if (!hideXAxis && !hideXAxisTicks) {
+          if (!hideXAxisTicks) {
             graphXAxisG.call(xAxis).call(rotateXTickLabels);
           }
 
-          if (!hideYAxis && !hideYAxisTicks) {
+          if (!hideYAxisTicks) {
             graphYAxisG.call(yAxis);
           }
 
@@ -1180,24 +1178,6 @@ export default class Linechart extends Stanza {
             previewYAxisYG.call(yAxisY);
           }
 
-          if (hideXAxis) {
-            graphXAxisG.call(hideTicks);
-            graphXAxisG.call((g) => g.select(".domain").remove());
-            if (showXPreview) {
-              previewXAxisXG.call(hideTicks);
-              previewXAxisXG.call((g) => g.select(".domain").remove());
-            }
-            xAxisTitleGroup.call((g) => g.select(".text").remove());
-          }
-          if (hideYAxis) {
-            graphYAxisG.call(hideTicks);
-            graphYAxisG.call((g) => g.select(".domain").remove());
-            if (showXPreview) {
-              previewXAxisYG.call(hideTicks);
-              previewXAxisYG.call((g) => g.select(".domain").remove());
-            }
-            yAxisTitleGroup.call((g) => g.select(".text").remove());
-          }
           if (hideXAxisTicks) {
             graphXAxisG.call(hideTicks);
             if (showXPreview) {

--- a/stanzas/linechart/metadata.json
+++ b/stanzas/linechart/metadata.json
@@ -216,20 +216,12 @@
       "stanza:required": false
     },
     {
-      "stanza:key": "points-show",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:description": "Show data points",
-      "stanza:required": false,
-      "stanza:default": false
-    },
-    {
-      "stanza:key": "points-size",
+      "stanza:key": "points_size",
       "stanza:type": "number",
-      "stanza:example": 10,
-      "stanza:description": "Data points size",
+      "stanza:example": 5,
+      "stanza:description": "Data points size in px",
       "stanza:required": false,
-      "stanza:default": 10
+      "stanza:default": 5
     },
     {
       "stanza:key": "error_bars-key",

--- a/stanzas/linechart/metadata.json
+++ b/stanzas/linechart/metadata.json
@@ -21,14 +21,6 @@
       "stanza:required": true
     },
     {
-      "stanza:key": "axis-x-visible",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:default": true,
-      "stanza:description": "Show the axis",
-      "stanza:required": false
-    },
-    {
       "stanza:key": "axis-x-title",
       "stanza:type": "text",
       "stanza:example": "Category",
@@ -125,14 +117,6 @@
       "stanza:example": "count",
       "stanza:description": "Variable to be assigned as y axis value. Ignored if data-type is CSV of TSV",
       "stanza:required": true
-    },
-    {
-      "stanza:key": "axis-y-visible",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:default": true,
-      "stanza:description": "Hide the axis",
-      "stanza:required": false
     },
     {
       "stanza:key": "axis-y-title",


### PR DESCRIPTION
- ポイントのサイズを `px` 単位に合わせました
- `points-show` を削除
- `points-size` を `points_size` 名前変更
- `points_size` が `0` か指定されていない場合は、points を表示しない
- `axis-x/y-visible` を削除