### PR TITLE
Feature/column tree

### DIFF
--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -26,7 +26,7 @@
         <strong class="title">
           {{ node[keys.label] }}
         </strong>
-        <span v-if="valueObj.show" class="value">
+        <span class="value">
           {{ node[keys.value] ?? valueObj.fallback }}
         </span>
       </span>

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -20,7 +20,7 @@
 
       <span
         class="label"
-        :class="`-${nodeContentAlignment}`"
+        :class="`-${nodeValueAlignment}`"
         @click="hasChildren(node.children) ? setParent(node.id) : null"
       >
         <strong class="title">
@@ -82,7 +82,7 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    nodeContentAlignment: {
+    nodeValueAlignment: {
       type: String,
       default: "horizontal",
     },

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -9,7 +9,7 @@
           '-highlighted':
             node.id === highlightedNode && hasChildren(node.children),
         },
-        { '-with-border': nodeShowBorders },
+        '-with-border',
       ]"
     >
       <input
@@ -77,10 +77,6 @@ export default defineComponent({
     highlightedNode: {
       type: [Number, String, null],
       default: null,
-    },
-    nodeShowBorders: {
-      type: Boolean,
-      default: false,
     },
     nodeValueAlignment: {
       type: String,

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -11,6 +11,7 @@
         },
         '-with-border',
       ]"
+      @click="hasChildren(node.children) ? setParent(node.id) : null"
     >
       <input
         type="checkbox"
@@ -18,11 +19,7 @@
         @input="setCheckedNode(node)"
       />
 
-      <span
-        class="label"
-        :class="`-${nodeValueAlignment}`"
-        @click="hasChildren(node.children) ? setParent(node.id) : null"
-      >
+      <span class="label" :class="`-${nodeValueAlignment}`">
         <strong class="title">
           {{ node[keys.label] }}
         </strong>

--- a/stanzas/column-tree/SearchSuggestions.vue
+++ b/stanzas/column-tree/SearchSuggestions.vue
@@ -14,11 +14,7 @@
           </span>
         </span>
         <span v-if="searchShowPath" class="value">
-          Path :
-          <ruby v-for="(item, pathIndex) of node.path" :key="pathIndex">
-            {{ item.label }}/<rp>(</rp><rt> {{ item.id }}</rt
-            ><rp>)</rp>
-          </ruby>
+          {{ getShowingPath(node.path) }}
         </span>
       </li>
       <li v-if="data.length < 1" class="no-results">
@@ -29,7 +25,7 @@
 </template>
 
 <script>
-import { defineComponent } from "vue";
+import { defineComponent, toRefs } from "vue";
 
 export default defineComponent({
   props: {
@@ -67,5 +63,17 @@ export default defineComponent({
     },
   },
   emits: ["selectNode"],
+  setup(params) {
+    params = toRefs(params);
+
+    function getShowingPath(pathArray) {
+      // pathArray.join("/").length < 200 ?
+      return "Transcript variant/ ... / ... / Coding var... ";
+    }
+
+    return {
+      getShowingPath,
+    };
+  },
 });
 </script>

--- a/stanzas/column-tree/SearchSuggestions.vue
+++ b/stanzas/column-tree/SearchSuggestions.vue
@@ -13,9 +13,6 @@
             {{ node[keys.value] ?? valueObj.fallback }}
           </span>
         </span>
-        <span v-if="searchShowPath" class="value">
-          {{ getShowingPath(node.path) }}
-        </span>
       </li>
       <li v-if="data.length < 1" class="no-results">
         {{ valueObj.fallback }}
@@ -25,15 +22,11 @@
 </template>
 
 <script>
-import { defineComponent, toRefs } from "vue";
+import { defineComponent } from "vue";
 
 export default defineComponent({
   props: {
     showSuggestions: {
-      type: Boolean,
-      default: false,
-    },
-    searchShowPath: {
       type: Boolean,
       default: false,
     },
@@ -63,17 +56,5 @@ export default defineComponent({
     },
   },
   emits: ["selectNode"],
-  setup(params) {
-    params = toRefs(params);
-
-    function getShowingPath(pathArray) {
-      // pathArray.join("/").length < 200 ?
-      return "Transcript variant/ ... / ... / Coding var... ";
-    }
-
-    return {
-      getShowingPath,
-    };
-  },
 });
 </script>

--- a/stanzas/column-tree/SearchSuggestions.vue
+++ b/stanzas/column-tree/SearchSuggestions.vue
@@ -7,7 +7,7 @@
         :class="{ '-with-border': nodeShowBorders }"
         @click="$emit('selectNode', node)"
       >
-        <span class="label" :class="`-${nodeContentAlignment}`">
+        <span class="label" :class="`-${nodeValueAlignment}`">
           <strong class="title">{{ node[keys.label] }}</strong>
           <span v-if="valueObj.show" class="value">
             {{ node[keys.value] ?? valueObj.fallback }}
@@ -57,7 +57,7 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    nodeContentAlignment: {
+    nodeValueAlignment: {
       type: String,
       default: "horizontal",
     },

--- a/stanzas/column-tree/SearchSuggestions.vue
+++ b/stanzas/column-tree/SearchSuggestions.vue
@@ -4,7 +4,7 @@
       <li
         v-for="(node, index) of data"
         :key="index"
-        :class="{ '-with-border': nodeShowBorders }"
+        :class="'-with-border'"
         @click="$emit('selectNode', node)"
       >
         <span class="label" :class="`-${nodeValueAlignment}`">
@@ -45,10 +45,6 @@ export default defineComponent({
     valueObj: {
       type: Object,
       required: true,
-    },
-    nodeShowBorders: {
-      type: Boolean,
-      default: false,
     },
     nodeValueAlignment: {
       type: String,

--- a/stanzas/column-tree/SearchSuggestions.vue
+++ b/stanzas/column-tree/SearchSuggestions.vue
@@ -9,7 +9,7 @@
       >
         <span class="label" :class="`-${nodeValueAlignment}`">
           <strong class="title">{{ node[keys.label] }}</strong>
-          <span v-if="valueObj.show" class="value">
+          <span class="value">
             {{ node[keys.value] ?? valueObj.fallback }}
           </span>
         </span>

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -18,7 +18,6 @@
         :data="suggestions"
         :keys="state.keys"
         :value-obj="valueObj"
-        :node-show-borders="state.nodeShowBorders"
         :node-value-alignment="state.nodeValueAlignment"
         @select-node="selectNode"
       />
@@ -35,7 +34,6 @@
         :keys="state.keys"
         :highlighted-node="state.highligthedNodes[index]"
         :value-obj="valueObj"
-        :node-show-borders="state.nodeShowBorders"
         :node-value-alignment="state.nodeValueAlignment"
         @set-parent="updatePartialColumnData"
         @set-checked-node="updateCheckedNodes"
@@ -99,7 +97,6 @@ export default defineComponent({
       },
       fallbackInCaseOfNoValue: params?.nodeValueFallback.value,
       nodeValueShow: params?.nodeValueShow?.value,
-      nodeShowBorders: params?.nodeShowBorders?.value,
       nodeValueAlignment: params?.nodeValueAlignment?.value,
       showSuggestions: false,
       responseJSON: [],

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -123,6 +123,7 @@ export default defineComponent({
       const data = state.responseJSON || [];
       state.columnData[0] = data.filter((obj) => isRootNode(obj.parent));
     });
+
     function updateCheckedNodes(node) {
       const { id, ...obj } = node;
       state.checkedNodes.has(id)
@@ -176,11 +177,14 @@ export default defineComponent({
     }
     function getPath(node) {
       const path = [];
-      let parent = { id: node.id, label: node.label };
-      while (parent.id) {
+      let parent = { id: node.id, label: node.label, parent: node.parent };
+      path.push(parent);
+      while (parent.parent) {
+        const obj = params?.data?.value?.find((obj) => {
+          return obj.id === parent.parent;
+        });
+        parent = { id: obj?.id, label: obj?.label, parent: obj?.parent };
         path.push(parent);
-        const obj = state.responseJSON.find((obj) => obj.id === parent.id);
-        parent = { id: obj?.parent, label: obj?.label };
       }
       return path.reverse();
     }
@@ -197,7 +201,7 @@ export default defineComponent({
       if (state.searchTerm.includes("/")) {
         return state.responseJSON.filter(isPathSearchHit);
       }
-      return state.responseJSON.filter(isNormalSearchHit);
+      return state.responseJSON.filter(isNormalSearchHit); // array of nodes.
     });
     return {
       isValidSearchNode,

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -20,7 +20,7 @@
         :keys="state.keys"
         :value-obj="valueObj"
         :node-show-borders="state.nodeShowBorders"
-        :node-content-alignment="state.nodeContentAlignment"
+        :node-value-alignment="state.nodeValueAlignment"
         @select-node="selectNode"
       />
     </div>
@@ -37,7 +37,7 @@
         :highlighted-node="state.highligthedNodes[index]"
         :value-obj="valueObj"
         :node-show-borders="state.nodeShowBorders"
-        :node-content-alignment="state.nodeContentAlignment"
+        :node-value-alignment="state.nodeValueAlignment"
         @set-parent="updatePartialColumnData"
         @set-checked-node="updateCheckedNodes"
       />
@@ -102,7 +102,7 @@ export default defineComponent({
       nodeValueShow: params?.nodeValueShow?.value,
       searchShowPath: params?.searchShowPath?.value,
       nodeShowBorders: params?.nodeShowBorders?.value,
-      nodeContentAlignment: params?.nodeContentAlignment?.value,
+      nodeValueAlignment: params?.nodeValueAlignment?.value,
       showSuggestions: false,
       responseJSON: [],
       columnData: [],

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -7,14 +7,13 @@
       <input
         v-model="state.searchTerm"
         type="text"
-        placeholder="Search for keywords or path*"
+        placeholder="Search for keywords"
         class="search"
         @focus="toggleSuggestionsIfValid"
         @input="toggleSuggestionsIfValid"
       />
       <search-suggestions
         :show-suggestions="state.showSuggestions"
-        :search-show-path="state.searchShowPath"
         :search-input="state.searchTerm"
         :data="suggestions"
         :keys="state.keys"
@@ -100,7 +99,6 @@ export default defineComponent({
       },
       fallbackInCaseOfNoValue: params?.nodeValueFallback.value,
       nodeValueShow: params?.nodeValueShow?.value,
-      searchShowPath: params?.searchShowPath?.value,
       nodeShowBorders: params?.nodeShowBorders?.value,
       nodeValueAlignment: params?.nodeValueAlignment?.value,
       showSuggestions: false,

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -96,7 +96,6 @@ export default defineComponent({
         value: params?.nodeValueKey?.value,
       },
       fallbackInCaseOfNoValue: params?.nodeValueFallback.value,
-      nodeValueShow: params?.nodeValueShow?.value,
       nodeValueAlignment: params?.nodeValueAlignment?.value,
       showSuggestions: false,
       responseJSON: [],
@@ -152,7 +151,6 @@ export default defineComponent({
     }
     const valueObj = computed(() => {
       return {
-        show: state.nodeValueShow,
         fallback: state.fallbackInCaseOfNoValue,
       };
     });

--- a/stanzas/column-tree/metadata.json
+++ b/stanzas/column-tree/metadata.json
@@ -36,33 +36,33 @@
       "stanza:required": true
     },
     {
-      "stanza:key": "node-show_borders",
-      "stanza:type": "boolean",
-      "stanza:example": false,
-      "stanza:description": "Show border between nodes"
+      "stanza:key": "node-value_key",
+      "stanza:example": "size",
+      "stanza:description": "Key for data attribute to display as value"
     },
     {
-      "stanza:key": "node-content_alignment",
+      "stanza:key": "node-value_alignment",
       "stanza:type": "single-choice",
       "stanza:choice": ["vertical", "horizontal"],
       "stanza:example": "horizontal",
       "stanza:description": "Set alignment of node content"
     },
     {
-      "stanza:key": "node-value-show",
+      "stanza:key": "node-value_fallback",
+      "stanza:example": "no data",
+      "stanza:description": "Message in case there is no data for data set by [node-value-key]"
+    },
+    {
+      "stanza:key": "node-show_borders",
+      "stanza:type": "boolean",
+      "stanza:example": false,
+      "stanza:description": "Show border between nodes"
+    },
+    {
+      "stanza:key": "node-value_show",
       "stanza:type": "boolean",
       "stanza:example": true,
       "stanza:description": "Show value set by [node-value-key] in tree and suggestions"
-    },
-    {
-      "stanza:key": "node-value-key",
-      "stanza:example": "n",
-      "stanza:description": "Key for data attribute to display as value"
-    },
-    {
-      "stanza:key": "node-value-fallback",
-      "stanza:example": "no data",
-      "stanza:description": "Message in case there is no data for data set by [node-value-key]"
     },
     {
       "stanza:key": "search-key",

--- a/stanzas/column-tree/metadata.json
+++ b/stanzas/column-tree/metadata.json
@@ -53,12 +53,6 @@
       "stanza:description": "Message in case there is no data for data set by [node-value-key]"
     },
     {
-      "stanza:key": "node-value_show",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:description": "Show value set by [node-value-key] in tree and suggestions"
-    },
-    {
       "stanza:key": "search-key",
       "stanza:example": "value",
       "stanza:description": "Key for data atrribute to search with suggestions."

--- a/stanzas/column-tree/metadata.json
+++ b/stanzas/column-tree/metadata.json
@@ -53,12 +53,6 @@
       "stanza:description": "Message in case there is no data for data set by [node-value-key]"
     },
     {
-      "stanza:key": "node-show_borders",
-      "stanza:type": "boolean",
-      "stanza:example": false,
-      "stanza:description": "Show border between nodes"
-    },
-    {
       "stanza:key": "node-value_show",
       "stanza:type": "boolean",
       "stanza:example": true,
@@ -172,6 +166,12 @@
       "stanza:type": "number",
       "stanza:default": 6,
       "stanza:description": "Horizontal padding for nodes"
+    },
+    {
+      "stanza:key": "--togostanza-node-borders_color",
+      "stanza:type": "color",
+      "stanza:default": "rgba(255,255,255,0)",
+      "stanza:description": "Border color between nodes"
     },
     {
       "stanza:key": "--togostanza-node-border_radius",

--- a/stanzas/column-tree/metadata.json
+++ b/stanzas/column-tree/metadata.json
@@ -67,13 +67,7 @@
     {
       "stanza:key": "search-key",
       "stanza:example": "value",
-      "stanza:description": "Key for data atrribute to search with suggestions. Besides this key, one can also search by path using the id followed by a / E.G.: 1/2/3"
-    },
-    {
-      "stanza:key": "search-show_path",
-      "stanza:type": "boolean",
-      "stanza:example": false,
-      "stanza:description": "Show path in suggestions"
+      "stanza:description": "Key for data atrribute to search with suggestions."
     },
     {
       "stanza:key": "togostanza-custom_css_url",

--- a/stanzas/column-tree/metadata.json
+++ b/stanzas/column-tree/metadata.json
@@ -126,6 +126,12 @@
       "stanza:description": "Background color for single column"
     },
     {
+      "stanza:key": "--togostanza-column-node_delimiter_width",
+      "stanza:type": "number",
+      "stanza:default": 0,
+      "stanza:description": "Border color between nodes"
+    },
+    {
       "stanza:key": "--togostanza-column-border_color",
       "stanza:type": "color",
       "stanza:default": "#D9D9D9",
@@ -160,12 +166,6 @@
       "stanza:type": "number",
       "stanza:default": 6,
       "stanza:description": "Horizontal padding for nodes"
-    },
-    {
-      "stanza:key": "--togostanza-node-borders_color",
-      "stanza:type": "color",
-      "stanza:default": "rgba(255,255,255,0)",
-      "stanza:description": "Border color between nodes"
     },
     {
       "stanza:key": "--togostanza-node-border_radius",

--- a/stanzas/column-tree/style.scss
+++ b/stanzas/column-tree/style.scss
@@ -58,7 +58,7 @@ main {
       width: 100%;
       top: 0;
       left: 0;
-      border-top: solid 1px var(--togostanza-column-border_color);
+      border-top: solid 1px var(--togostanza-node-borders_color);
     }
   }
   > .search-container {

--- a/stanzas/column-tree/style.scss
+++ b/stanzas/column-tree/style.scss
@@ -58,7 +58,9 @@ main {
       width: 100%;
       top: 0;
       left: 0;
-      border-top: solid 1px var(--togostanza-node-borders_color);
+      border-top: solid
+        calc(var(--togostanza-column-node_delimiter_width) * 1px)
+        var(--togostanza-column-border_color);
     }
   }
   > .search-container {


### PR DESCRIPTION
以下の変更を行いました。
- 記号 > も含めてクリッカブルのエリアを広くしました。
- parameter`node-show_borders`を削除し、styleに`--togostanza-column-node_delimiter_width`を追加。
- paramsを以下の順にし、名称も変更。
  `node-label_key`
  `node-value_key`
  `node-value_alignment`
  `node-value_fallback`
- 一旦完成してリリースするために`search-show_path`を削除しました。

ご確認をお願いいたします。