### PR TITLE
Force chart fix params names

### DIFF
--- a/lib/prepareGraphData.js
+++ b/lib/prepareGraphData.js
@@ -75,7 +75,6 @@ export default function (nodesC, edgesC, params) {
 
   // Edges width
   const edgeWidthScale = getScaleFunc(edgeWidthParams.scale)
-
     .domain(d3.extent(edgesC, (d) => d[edgeWidthParams.dataKey]))
     .range([edgeWidthParams.minWidth, edgeWidthParams.maxWidth]);
 
@@ -91,7 +90,6 @@ export default function (nodesC, edgesC, params) {
       );
       edge[symbols.edgeWidthSym] = edgeWidthParams.minWidth;
     }
-
 
     edge[symbols.sourceNodeSym] = nodeHash[edge.source];
     edge[symbols.targetNodeSym] = nodeHash[edge.target];
@@ -290,7 +288,7 @@ export const getGroupPlanes = (groupHash, planeParams, circular = false) => {
 
 function getScaleFunc(scaleStr) {
   switch (scaleStr) {
-    case "sqrt":
+    case "square root":
       return d3.scaleSqrt();
     case "log10":
       return d3.scaleLog();

--- a/stanzas/force-graph/index.js
+++ b/stanzas/force-graph/index.js
@@ -59,22 +59,22 @@ export default class ForceGraph extends Stanza {
     const edges = values.links;
 
     const nodeSizeParams = {
-      dataKey: this.params["node-size-key"] || "",
-      minSize: setFallbackVal("node-size-min", 0),
-      maxSize: this.params["node-size-max"],
-      scale: this.params["node-size-scale"] || "linear",
+      dataKey: this.params["node-size_key"] || "",
+      minSize: setFallbackVal("node-size_min", 0),
+      maxSize: this.params["node-size_max"],
+      scale: this.params["node-size_scale"] || "linear",
     };
 
     const nodeColorParams = {
-      dataKey: this.params["node-color-key"] || "",
+      dataKey: this.params["node-color_key"] || "",
     };
 
     const edgeWidthParams = {
-      dataKey: this.params["edge-width-key"] || "",
-      minWidth: setFallbackVal("edge-width-min", 1),
-      maxWidth: this.params["edge-width-max"],
-      scale: this.params["edge-width-scale"] || "linear",
-      showArrows: this.params["edge-show_arrows"],
+      dataKey: this.params["edge-width_key"] || "",
+      minWidth: setFallbackVal("edge-width_min", 1),
+      maxWidth: this.params["edge-width_max"],
+      scale: this.params["edge-width_scale"] || "linear",
+      showArrows: this.params["edge-arrows_visible"],
     };
 
     const edgeColorParams = {
@@ -84,7 +84,7 @@ export default class ForceGraph extends Stanza {
 
     const labelsParams = {
       margin: 3,
-      dataKey: this.params["node-label-key"],
+      dataKey: this.params["node-label_key"],
     };
 
     const highlightAdjEdges = true;
@@ -92,8 +92,8 @@ export default class ForceGraph extends Stanza {
     const MARGIN = getMarginsFromCSSString(css("--togostanza-canvas-padding"));
 
     const tooltipParams = {
-      dataKey: this.params["node-tooltip-key"],
-      show: nodes.some((d) => d[this.params["node-tooltip-key"]]),
+      dataKey: this.params["node-tooltip_key"],
+      show: nodes.some((d) => d[this.params["node-tooltip_key"]]),
     };
 
     // Setting color scale

--- a/stanzas/force-graph/metadata.json
+++ b/stanzas/force-graph/metadata.json
@@ -27,76 +27,76 @@
       "stanza:required": true
     },
     {
-      "stanza:key": "node-size-key",
+      "stanza:key": "node-size_key",
       "stanza:type": "string",
       "stanza:example": "",
       "stanza:description": "Set size on the node based on data key, or fallback to value of node-size-min"
     },
     {
-      "stanza:key": "node-size-min",
+      "stanza:key": "node-size_min",
       "stanza:type": "number",
       "stanza:example": 3,
       "stanza:description": "Minimum node radius in px (fallback to 0)"
     },
     {
-      "stanza:key": "node-size-max",
+      "stanza:key": "node-size_max",
       "stanza:type": "number",
       "stanza:example": 6,
       "stanza:description": "Maximum node radius in px"
     },
     {
-      "stanza:key": "node-size-scale",
+      "stanza:key": "node-size_scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "sqrt", "log10"],
-      "stanza:example": "sqrt",
+      "stanza:choice": ["linear", "square root", "log10"],
+      "stanza:example": "square root",
       "stanza:description": "Node radius scale"
     },
     {
-      "stanza:key": "node-color-key",
+      "stanza:key": "node-color_key",
       "stanza:type": "string",
       "stanza:example": "group",
       "stanza:description": "Set color of the node based on data key"
     },
     {
-      "stanza:key": "edge-width-key",
+      "stanza:key": "edge-width_key",
       "stanza:type": "string",
       "stanza:example": "value",
       "stanza:description": "Set width of the edge  data key"
     },
 
     {
-      "stanza:key": "edge-width-min",
+      "stanza:key": "edge-width_min",
       "stanza:type": "number",
       "stanza:example": 1,
       "stanza:description": "Minimum edge width in px"
     },
     {
-      "stanza:key": "edge-width-max",
+      "stanza:key": "edge-width_max",
       "stanza:type": "number",
       "stanza:example": 1,
       "stanza:description": "Maximum edge width in px"
     },
     {
-      "stanza:key": "edge-width-scale",
+      "stanza:key": "edge-width_scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "sqrt", "log10"],
+      "stanza:choice": ["linear", "square root", "log10"],
       "stanza:example": "linear",
       "stanza:description": "Edge width scale"
     },
     {
-      "stanza:key": "edge-show_arrows",
+      "stanza:key": "edge-arrows_visible",
       "stanza:type": "boolean",
       "stanza:example": "true",
       "stanza:description": "Show arrows"
     },
     {
-      "stanza:key": "node-label-key",
+      "stanza:key": "node-label_key",
       "stanza:type": "string",
       "stanza:example": "id",
       "stanza:description": "Node labels data key. If empty, no labels will be shown"
     },
     {
-      "stanza:key": "node-tooltip-key",
+      "stanza:key": "node-tooltip_key",
       "stanza:type": "string",
       "stanza:example": "id",
       "stanza:description": "Node tooltips data key. If empty, no tooltips will be shown"


### PR DESCRIPTION
### node

- [x] node-label-key → node-label_key
- [x] node-size-key → node-size_key
- [x] node-size-min → node-size_min
- [x] node-size-max → node-size_max
- [x] node-size-scale → node-size_scale
- [x] linear, sqrt → square root, log10
- [x] node-color-key → node-color_key
- [x] node-tooltip-key → node-tooltip_key
  - 残すなら他のMetaStanzaでも任意のtooltipを指定する機能が付けられるところがないか見直していく
  - こちらもfallbackがあって良い可能性もあるけど、現状では鬱陶しいだけかなという判断で保留

### edge
- [x] edge-width-key → edge-width_key
- [x] edge-width-min → edge-width_min
- [x] edge-width-max → edge-width_max
- [x] edge-width-scale → edge-width_scale
- [x] edge-show_arrows → edge-arrows_visible