### PR TITLE
Feature/layered graph

### DIFF
--- a/lib/GraphDataSchema.ts
+++ b/lib/GraphDataSchema.ts
@@ -1,12 +1,5 @@
 import { z } from "zod";
 
-// z
-//   .object({
-//     id: z.union([z.number(), z.string()],{required_error: "key `id` is required"}),
-//     group: z.union([z.number(), z.string()], {required_error: "key `group` is required"}),
-//   })
-//   .passthrough();
-
 const NodesListModel = z
   .object({
     id: z.union([z.number(), z.string()], {

--- a/lib/GraphDataSchema.ts
+++ b/lib/GraphDataSchema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+// z
+//   .object({
+//     id: z.union([z.number(), z.string()],{required_error: "key `id` is required"}),
+//     group: z.union([z.number(), z.string()], {required_error: "key `group` is required"}),
+//   })
+//   .passthrough();
+
+const NodesListModel = z
+  .object({
+    id: z.union([z.number(), z.string()], {
+      required_error: "key `id` is required",
+    }),
+  })
+  .passthrough();
+
+const LayeredGraphNodesListModel = NodesListModel.extend({
+  group: z.union([z.number(), z.string()], {
+    required_error: "key `group` is required",
+  }),
+});
+
+const EgdesListModel = z
+  .object({
+    source: z.union([z.number(), z.string()]),
+    target: z.union([z.number(), z.string()]),
+  })
+  .passthrough();
+
+export const GraphDataModel = z
+  .object({
+    nodes: z.array(NodesListModel, {
+      required_error: "key `nodes` is required",
+      description: "Nodes array",
+    }),
+    links: z.array(EgdesListModel, {
+      required_error: "key `links` is required",
+      description: "Links (edges) array",
+    }),
+  })
+  .passthrough();
+
+export const LayeredGraphDataModel = GraphDataModel.extend({
+  nodes: z.array(LayeredGraphNodesListModel, {
+    required_error: "key `nodes` is required",
+    description: "Array of nodes with group information",
+  }),
+});
+
+export type GraphDataT = z.infer<typeof GraphDataModel>;
+export type LayeredGraphDataT = z.infer<typeof LayeredGraphDataModel>;

--- a/lib/prepareGraphData.js
+++ b/lib/prepareGraphData.js
@@ -59,19 +59,19 @@ export default function (nodesC, edgesC, params) {
       return 0;
     });
   }
-  const nodeHash = {};
+  const nodeHash = new Map();
 
-  const groupHash = {};
+  const groupHash = new Map();
 
   nodesC.forEach((node) => {
     const groupName = "" + node.group;
-    if (groupHash[groupName]) {
-      groupHash[groupName].push(node);
+    if (groupHash.has(groupName)) {
+      groupHash.get(groupName).push(node);
     } else {
-      groupHash[groupName] = [node];
+      groupHash.set(groupName, [node]);
     }
 
-    nodeHash[node.id] = node;
+    nodeHash.set(node.id, node);
   });
 
   // Edges width
@@ -92,8 +92,8 @@ export default function (nodesC, edgesC, params) {
       edge[symbols.edgeWidthSym] = edgeWidthParams.minWidth;
     }
 
-    edge[symbols.sourceNodeSym] = nodeHash[edge.source];
-    edge[symbols.targetNodeSym] = nodeHash[edge.target];
+    edge[symbols.sourceNodeSym] = nodeHash.get(edge.source);
+    edge[symbols.targetNodeSym] = nodeHash.get(edge.target);
     edge[symbols.idSym] = uuidv4();
   });
   // ===
@@ -242,14 +242,15 @@ export const get3DEdges = (edgesC) => {
 
 /**
  * Returns group planes objects
- * @param {Object} groupHash - groups hash table. {[groupId]: [{node1}, {node2}, ...]}
+ * @param {Map} groupHash - groups hash table. {[groupId]: [{node1}, {node2}, ...]}
  * @param {Object} planeParams - plane params. {WIDTH, HEIGHT, DEPTH, color}
  * @returns {Array} group planes objects array
  */
 export const getGroupPlanes = (groupHash, planeParams, circular = false) => {
   const groupIds = Object.keys(groupHash);
   const { WIDTH, groupPlaneColorParams } = planeParams;
-  const groupColor = planeParams.color().domain(groupIds.sort());
+  const sortedGroupIds = groupIds.sort((a, b) => Number(a) - Number(b));
+  const groupColor = planeParams.color().domain(sortedGroupIds);
 
   let getGroupPlane;
 
@@ -291,7 +292,7 @@ export const getGroupPlanes = (groupHash, planeParams, circular = false) => {
     };
   }
 
-  return groupIds.map(getGroupPlane);
+  return sortedGroupIds.map(getGroupPlane);
 };
 
 function getScaleFunc(scaleStr) {

--- a/lib/prepareGraphData.js
+++ b/lib/prepareGraphData.js
@@ -42,6 +42,7 @@ export default function (nodesC, edgesC, params) {
     edgeWidthParams,
     edgeColorParams,
     nodesSortParams,
+    nodeLabelParams,
   } = params;
 
   if (
@@ -137,6 +138,13 @@ export default function (nodesC, edgesC, params) {
     });
   }
   // ===
+
+  // Nodes labels
+  if (nodesC.some((d) => d[nodeLabelParams.dataKey])) {
+    nodesC.forEach((node) => {
+      node[symbols.nodeLabelSym] = node[nodeLabelParams.dataKey] || null;
+    });
+  }
 
   //Edges color
   if (

--- a/stanzas/force-graph/drawForceLayout.js
+++ b/stanzas/force-graph/drawForceLayout.js
@@ -54,7 +54,7 @@ export default function (
     width,
     height,
     MARGIN,
-    labelsParams,
+    nodeLabelParams,
     tooltipParams,
     highlightAdjEdges,
     edgeWidthParams,
@@ -199,15 +199,15 @@ export default function (
     nodeCircles.attr("data-tooltip", (d) => d[tooltipParams.dataKey]);
   }
 
-  if (labelsParams.dataKey !== "" && nodes[0][labelsParams.dataKey]) {
+  if (nodeLabelParams.dataKey !== "" && nodes[0][nodeLabelParams.dataKey]) {
     nodeGroups
       .append("text")
       .attr("x", 0)
-      .attr("dy", (d) => labelsParams.margin + d[symbols.nodeSizeSym])
+      .attr("dy", (d) => nodeLabelParams.margin + d[symbols.nodeSizeSym])
       .attr("class", "label")
       .attr("alignment-baseline", "hanging")
       .attr("text-anchor", "middle")
-      .text((d) => d[labelsParams.dataKey]);
+      .text((d) => d[nodeLabelParams.dataKey]);
   }
 
   let isDragging = false;

--- a/stanzas/force-graph/index.js
+++ b/stanzas/force-graph/index.js
@@ -82,7 +82,7 @@ export default class ForceGraph extends Stanza {
       dataKey: Symbol(),
     };
 
-    const labelsParams = {
+    const nodeLabelParams = {
       margin: 3,
       dataKey: this.params["node-label_key"],
     };
@@ -141,7 +141,7 @@ export default class ForceGraph extends Stanza {
       nodeColorParams,
       edgeWidthParams,
       edgeColorParams,
-      labelsParams,
+      nodeLabelParams,
       tooltipParams,
     };
 

--- a/stanzas/force-graph/style.scss
+++ b/stanzas/force-graph/style.scss
@@ -23,6 +23,7 @@ svg > defs > marker > path {
   fill: var(--togostanza-theme-series_0_color);
   stroke: var(--togostanza-border-color);
   stroke-width: var(--togostanza-border-width);
+  cursor: pointer;
 }
 
 .link {

--- a/stanzas/graph-2d-circle/drawCircleLayout.js
+++ b/stanzas/graph-2d-circle/drawCircleLayout.js
@@ -9,7 +9,7 @@ export default function (
     height,
     MARGIN,
     symbols,
-    labelsParams,
+    nodeLabelParams,
     tooltipParams,
     highlightAdjEdges,
     edgeParams,
@@ -132,10 +132,10 @@ export default function (
     nodeCircles.attr("data-tooltip", (d) => d[tooltipParams.dataKey]);
   }
 
-  if (labelsParams.dataKey !== "" && nodes[0][labelsParams.dataKey]) {
+  if (nodeLabelParams.dataKey !== "" && nodes[0][nodeLabelParams.dataKey]) {
     nodeGroups
       .append("text")
-      .text((d) => d[labelsParams.dataKey])
+      .text((d) => d[nodeLabelParams.dataKey])
       .attr("alignment-baseline", "middle")
       .attr("text-anchor", (d) => {
         if (angleScale(d.id) > 90 && angleScale(d.id) < 270) {
@@ -145,9 +145,9 @@ export default function (
       })
       .attr("x", (d) => {
         if (angleScale(d.id) > 90 && angleScale(d.id) < 270) {
-          return -labelsParams.margin - d[symbols.nodeSizeSym];
+          return -nodeLabelParams.margin - d[symbols.nodeSizeSym];
         }
-        return labelsParams.margin + d[symbols.nodeSizeSym];
+        return nodeLabelParams.margin + d[symbols.nodeSizeSym];
       })
       .attr("transform", (d) => {
         if (angleScale(d.id) > 90 && angleScale(d.id) < 270) {

--- a/stanzas/graph-2d-circle/index.js
+++ b/stanzas/graph-2d-circle/index.js
@@ -113,7 +113,7 @@ export default class ForceGraph extends Stanza {
       dataKey: this.params["edge-color-data-key"] || "",
     };
 
-    const labelsParams = {
+    const nodeLabelParams = {
       margin: this.params["labels-margin"],
       dataKey: this.params["labels-data-key"],
     };
@@ -143,7 +143,7 @@ export default class ForceGraph extends Stanza {
       edgeWidthParams,
       edgeColorParams,
       edgeParams,
-      labelsParams,
+      nodeLabelParams,
       tooltipParams,
     };
 

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -344,10 +344,10 @@ export default class ForceGraph extends Stanza {
         nodeGroup
           .append("text")
           .classed("node-label", true)
-          .text((d) => d[symbols.nodeLabelSym])
+          .text((d) => d[symbols.nodeLabelSym] || "")
           .attr("alignment-baseline", "hanging")
           .attr("text-anchor", "middle")
-          .attr("y", 2);
+          .attr("y", (d) => d[symbols.nodeSizeSym] + 2);
       }
 
       points.sort(point3d.sort);
@@ -438,7 +438,7 @@ export default class ForceGraph extends Stanza {
       processData(data);
 
       const planes = svgG.selectAll("path.group-plane");
-      const points = svgG.selectAll("circle.node");
+      const points = svgG.selectAll("g.node-g");
       const links = svgG.selectAll("path.link");
 
       if (highlightGroupPlanes) {

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -225,10 +225,7 @@ export default class ForceGraph extends Stanza {
         .attr("fill-opacity", 1);
     }
 
-    const maxNodesInGroup = d3.max(
-      Object.entries(groupHash),
-      (d) => d[1].length
-    );
+    const maxNodesInGroup = d3.max([...groupHash.values()], (d) => d.length);
 
     const Rmax = (0.8 * WIDTH) / 2;
 
@@ -370,24 +367,19 @@ export default class ForceGraph extends Stanza {
       // Add x,y,z of source and target nodes to 3D edges
       edgesWithCoords = get3DEdges(prepEdges);
 
-      // Laying out nodes=========
-      const DEPTH = HEIGHT;
-      const yPointScale = d3.scalePoint([-DEPTH / 2, DEPTH / 2]).domain(
-        Object.keys(groupHash).sort((a, b) => {
-          if (a > b) {
-            return groupsSortParams.sortOrder === "ascending" ? 1 : -1;
-          }
-          if (a < b) {
-            return groupsSortParams.sortOrder === "ascending" ? -1 : 1;
-          }
-          return 0;
-        })
+      const sortedGroupHash = new Map(
+        [...groupHash.entries()].sort(([a], [b]) => Number(a) - Number(b))
       );
 
-      Object.keys(groupHash).forEach((gKey) => {
-        // Laying out nodes ===
+      const sortedGroupKeys = [...sortedGroupHash.keys()];
+      // Laying out nodes=========
+      const DEPTH = HEIGHT;
+      const yPointScale = d3
+        .scalePoint([-DEPTH / 2, DEPTH / 2])
+        .domain(sortedGroupKeys);
 
-        const group = groupHash[gKey];
+      sortedGroupHash.forEach((group, gKey) => {
+        // Laying out nodes ===
 
         const angleScale = d3
           .scalePoint()
@@ -413,7 +405,7 @@ export default class ForceGraph extends Stanza {
       });
 
       groupPlanes = getGroupPlanes(
-        groupHash,
+        Object.fromEntries(sortedGroupHash.entries()),
         {
           WIDTH,
           HEIGHT,

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -89,7 +89,7 @@ export default class ForceGraph extends Stanza {
     this.tooltip = new ToolTip();
     root.append(this.tooltip);
 
-    const constRarius = !!this.params["group_planes-constant_radius"];
+    const constRarius = false;
 
     const groupPlaneColorParams = {
       colorPlane: false,

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -352,10 +352,6 @@ export default class ForceGraph extends Stanza {
 
       points.sort(point3d.sort);
 
-      if (tooltipParams.show) {
-        p.attr("data-tooltip", (d) => d[tooltipParams.dataKey]);
-      }
-
       points.exit().remove();
     }
 
@@ -541,7 +537,6 @@ export default class ForceGraph extends Stanza {
 
         d3.select(this).classed("active", true).classed("fadeout", false);
 
-        console.log(points.nodes());
         // highlight nodes belonging to this group
         points.classed("fadeout", true);
         points.classed("active", false);
@@ -666,6 +661,10 @@ export default class ForceGraph extends Stanza {
     init();
 
     if (tooltipParams.show) {
+      const points = svgG.selectAll("circle.node");
+      points.attr("data-tooltip", (d) => {
+        return d[tooltipParams.dataKey];
+      });
       this.tooltip.setup(el.querySelectorAll("[data-tooltip]"));
     }
   }

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -140,7 +140,7 @@ export default class ForceGraph extends Stanza {
     };
 
     const highlightAdjEdges = true;
-    const highlightGroupPlanes = this.params["highlight-group_planes"] || false;
+    const highlightGroupPlanes = true;
 
     const params = {
       MARGIN,

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -4,7 +4,7 @@ import { _3d } from "d3-3d";
 import loadData from "togostanza-utils/load-data";
 import ToolTip from "@/lib/ToolTip";
 import { StanzaColorGenerator } from "@/lib/ColorGenerator";
-
+import { LayeredGraphDataModel } from "@/lib/GraphDataSchema";
 import { curvedLink, straightLink } from "./curvedLink";
 import prepareGraphData, {
   get3DEdges,
@@ -52,10 +52,12 @@ export default class ForceGraph extends Stanza {
 
     const cg = new StanzaColorGenerator(this);
 
-    const values = await loadData(
-      this.params["data-url"],
-      this.params["data-type"],
-      this.root.querySelector("main")
+    const values = LayeredGraphDataModel.parse(
+      await loadData(
+        this.params["data-url"],
+        this.params["data-type"],
+        this.root.querySelector("main")
+      )
     );
 
     this._data = values;

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -27,6 +27,12 @@
       "stanza:required": true
     },
     {
+      "stanza:key": "data-directed_graph",
+      "stanza:type": "boolean",
+      "stanza:example": "true",
+      "stanza:description": "Whether the graph data is directed (whether to show the arrows or not)"
+    },
+    {
       "stanza:key": "node-label_key",
       "stanza:type": "string",
       "stanza:example": "id",
@@ -100,12 +106,6 @@
       "stanza:choice": ["linear", "sqrt", "log10"],
       "stanza:example": "linear",
       "stanza:description": "Edge width scale"
-    },
-    {
-      "stanza:key": "edge-show_arrows",
-      "stanza:type": "boolean",
-      "stanza:example": "true",
-      "stanza:description": "Show arrows"
     },
     {
       "stanza:key": "highlight-group_planes",

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -108,12 +108,6 @@
       "stanza:description": "Edge width scale"
     },
     {
-      "stanza:key": "highlight-group_planes",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:description": "Highlight group planes on mouse hover"
-    },
-    {
       "stanza:key": "tooltips-key",
       "stanza:type": "string",
       "stanza:example": "id",

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -40,6 +40,12 @@
       "stanza:description": "Group planes sorting order"
     },
     {
+      "stanza:key": "node-label_key",
+      "stanza:type": "string",
+      "stanza:example": "id",
+      "stanza:description": "Node labels data key. If empty, no labels will be shown"
+    },
+    {
       "stanza:key": "nodes-sort-key",
       "stanza:type": "string",
       "stanza:example": "id",

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -27,19 +27,6 @@
       "stanza:required": true
     },
     {
-      "stanza:key": "group_planes-sort-key",
-      "stanza:type": "string",
-      "stanza:example": "group",
-      "stanza:description": "Sort group planes by this data key value"
-    },
-    {
-      "stanza:key": "group_planes-sort-order",
-      "stanza:type": "single-choice",
-      "stanza:choice": ["ascending", "descending"],
-      "stanza:example": "ascending",
-      "stanza:description": "Group planes sorting order"
-    },
-    {
       "stanza:key": "node-label_key",
       "stanza:type": "string",
       "stanza:example": "id",

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -209,7 +209,7 @@
     {
       "stanza:key": "--togostanza-edge-color",
       "stanza:type": "color",
-      "stanza:default": "#bdbdbd",
+      "stanza:default": "#999999",
       "stanza:description": "Egdes default color"
     },
     {

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -148,6 +148,24 @@
   "stanza:menu-placement": "bottom-right",
   "stanza:style": [
     {
+      "stanza:key": "--togostanza-fonts-font_family",
+      "stanza:type": "text",
+      "stanza:default": "Helvetica Neue",
+      "stanza:description": "Font family"
+    },
+    {
+      "stanza:key": "--togostanza-fonts-font_color",
+      "stanza:type": "color",
+      "stanza:default": "#4E5059",
+      "stanza:description": "Label font color"
+    },
+    {
+      "stanza:key": "--togostanza-fonts-font_size_primary",
+      "stanza:type": "number",
+      "stanza:default": 9,
+      "stanza:description": "Label font size"
+    },
+    {
       "stanza:key": "--togostanza-canvas-width",
       "stanza:type": "number",
       "stanza:default": 600,

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -121,12 +121,6 @@
       "stanza:description": "Show arrows"
     },
     {
-      "stanza:key": "group_planes-constant_radius",
-      "stanza:type": "boolean",
-      "stanza:example": true,
-      "stanza:description": "Constant radius for all groups"
-    },
-    {
       "stanza:key": "highlight-group_planes",
       "stanza:type": "boolean",
       "stanza:example": true,

--- a/stanzas/layered-graph/style.scss
+++ b/stanzas/layered-graph/style.scss
@@ -20,33 +20,35 @@ svg > defs > marker > path {
   transition-property: opacity, stroke-width, stroke-opacity;
 }
 
-.node {
-  fill: var(--togostanza-theme-series_0_color);
-  stroke-width: calc(var(--togostanza-border-width) * 1px);
-  stroke: var(--togostanza-border-color);
-  cursor: pointer;
+g.node-g {
+  > .node {
+    fill: var(--togostanza-theme-series_0_color);
+    stroke-width: calc(var(--togostanza-border-width) * 1px);
+    stroke: var(--togostanza-border-color);
+    cursor: pointer;
+  }
   &.active {
-    opacity: 1;
-    stroke-width: calc(var(--togostanza-border-width) * 2.5px);
+    > .node-label {
+      opacity: 1;
+    }
+    > .node {
+      opacity: 1;
+      stroke-width: calc(var(--togostanza-border-width) * 2.5px);
+    }
   }
   &.half-active {
-    stroke-opacity: 0.5;
-    stroke-width: calc(var(--togostanza-border-width) * 1.5px);
+    > .node-label {
+      stroke-opacity: 0.5;
+    }
+    > .node {
+      stroke-opacity: 0.5;
+      stroke-width: calc(var(--togostanza-border-width) * 1.5px);
+    }
   }
   &.fadeout {
-    opacity: 0.1;
-  }
-}
-
-.node-label {
-  &.active {
-    opacity: 1;
-  }
-  &.half-active {
-    stroke-opacity: 0.5;
-  }
-  &.fadeout {
-    opacity: 0.1;
+    > * {
+      opacity: 0.1;
+    }
   }
 }
 

--- a/stanzas/layered-graph/style.scss
+++ b/stanzas/layered-graph/style.scss
@@ -38,6 +38,18 @@ svg > defs > marker > path {
   }
 }
 
+.node-label {
+  &.active {
+    opacity: 1;
+  }
+  &.half-active {
+    stroke-opacity: 0.5;
+  }
+  &.fadeout {
+    opacity: 0.1;
+  }
+}
+
 .link {
   stroke-linecap: round;
   stroke-width: 1px;

--- a/stanzas/layered-graph/style.scss
+++ b/stanzas/layered-graph/style.scss
@@ -58,13 +58,13 @@ g.node-g {
   fill: none;
   stroke: var(--togostanza-edge-color);
   pointer-events: none;
-  opacity: 0.8;
+  opacity: 0.6;
 
   &.active {
-    opacity: 1;
+    opacity: 0.4;
   }
   &.half-active {
-    opacity: 1;
+    opacity: 0.4;
   }
   &.fadeout {
     opacity: 0.01;


### PR DESCRIPTION
- ノードのラベルを追加
- レイヤーをまたぐエッジを常点線に変更
- `highlight_planes` を常に `true` に変更、paramを削除
- edges opacity 修正
- `group_planes-constant_radius` を常に`false` で、そのparamを削除
- `edge-show_arrows`を　dataに移動 (`data-directed_graph`)
- group のレイヤーのソート修正（数値としてソート）
- データ形式のバリデーション追加　（`lib/GraphDataSchema.ts`）
- `prepareGraphData` リファクタリング
  - それに伴う　Force chart と Circle 2d graph 修正