### PR TITLE
Piechart(remove main from style.scss)

### DIFF
--- a/stanzas/piechart/style.scss
+++ b/stanzas/piechart/style.scss
@@ -3,16 +3,15 @@
 
 // The following is just an example. Feel free to modify it.
 // --greeting-color and --greeting-align are style variables, which are defined in metadata.json.
-main {
-  > svg {
-    path.pie-slice {
-      stroke: var(--togostanza-border-color);
-      stroke-width: 0.5px;
 
-      &.-fadeout {
-        opacity: var(--togostanza-fadeout-opacity);
-        transition: var(--togostanza-fadeout-transition);
-      }
+svg {
+  path.pie-slice {
+    stroke: var(--togostanza-border-color);
+    stroke-width: 0.5px;
+
+    &.-fadeout {
+      opacity: var(--togostanza-fadeout-opacity);
+      transition: var(--togostanza-fadeout-transition);
     }
   }
 }


### PR DESCRIPTION
ダウンロードの際にpathが表示されない件について、style.scssからmainを削除することで表示されるようになりました。ご確認をお願いします。