### PR TITLE
column tree can be checked from other graphs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,6 +153,7 @@ export function emitSelectedEventForD3({
   targetElementSelector,
   selectedElementSelector,
   idPath,
+  dataUrl,
 }) {
   // get filter nodes
   const targetElements = drawing.selectAll(targetElementSelector);
@@ -172,7 +173,7 @@ export function emitSelectedEventForD3({
 
   rootElement.dispatchEvent(
     new CustomEvent("changeSelectedNodes", {
-      detail: selectedIds,
+      detail: { selectedIds, dataUrl },
     })
   );
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,7 +173,7 @@ export function emitSelectedEventForD3({
 
   rootElement.dispatchEvent(
     new CustomEvent("changeSelectedNodes", {
-      detail: { selectedIds, dataUrl },
+      detail: { targetId, selectedIds, dataUrl },
     })
   );
 }

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -19,7 +19,7 @@
           class="selectable"
           :class="{ '-selected': checkedNodes.get(node.id) }"
           type="checkbox"
-          :checked="checkedNodes.get(node.id)"
+          :checked="checkedNodes.get(node.__togostanza_id__)"
           @input="handleCheckboxClick(node)"
         />
 
@@ -109,32 +109,35 @@ export default defineComponent({
     }
 
     function handleCheckboxClick(node) {
+      // console.log(node);
       setCheckedNode(node);
+      // console.log(this.checkedNodes);
+      console.log([...this.checkedNodes.keys()]);
 
       const drawing = document.querySelector("togostanza-column-tree");
 
-      // get filter nodes
-      const targetElements = Array.from(
-        drawing.shadowRoot.querySelectorAll("input.selectable")
-      );
-      const selectedElements = targetElements.filter((el) => {
-        return el.classList.contains("-selected");
-      });
-      const selectedIds = selectedElements.map(
-        (el) => +el.dataset.togostanzaId
-      );
+      // // get filter nodes
+      // const targetElements = Array.from(
+      //   drawing.shadowRoot.querySelectorAll("input.selectable")
+      // );
+      // const selectedElements = targetElements.filter((el) => {
+      //   return el.classList.contains("-selected");
+      // });
+      // const selectedIds = selectedElements.map(
+      //   (el) => +el.dataset.togostanzaId
+      // );
 
-      const targetId = node.__togostanza_id__;
+      // const targetId = node.__togostanza_id__;
 
-      if (!selectedIds.includes(targetId)) {
-        selectedIds.push(targetId);
-      } else {
-        selectedIds.splice(selectedIds.indexOf(targetId), 1);
-      }
+      // if (!selectedIds.includes(targetId)) {
+      //   selectedIds.push(targetId);
+      // } else {
+      //   selectedIds.splice(selectedIds.indexOf(targetId), 1);
+      // }
 
       drawing.dispatchEvent(
         new CustomEvent("changeSelectedNodes", {
-          detail: { selectedIds, dataUrl: "" },
+          detail: { selectedIds: [...this.checkedNodes.keys()], dataUrl: "" },
         })
       );
     }

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -134,7 +134,7 @@ export default defineComponent({
 
       drawing.dispatchEvent(
         new CustomEvent("changeSelectedNodes", {
-          detail: selectedIds,
+          detail: { selectedIds, dataUrl: "" },
         })
       );
     }

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -109,31 +109,9 @@ export default defineComponent({
     }
 
     function handleCheckboxClick(node) {
-      // console.log(node);
       setCheckedNode(node);
-      // console.log(this.checkedNodes);
-      console.log([...this.checkedNodes.keys()]);
 
       const drawing = document.querySelector("togostanza-column-tree");
-
-      // // get filter nodes
-      // const targetElements = Array.from(
-      //   drawing.shadowRoot.querySelectorAll("input.selectable")
-      // );
-      // const selectedElements = targetElements.filter((el) => {
-      //   return el.classList.contains("-selected");
-      // });
-      // const selectedIds = selectedElements.map(
-      //   (el) => +el.dataset.togostanzaId
-      // );
-
-      // const targetId = node.__togostanza_id__;
-
-      // if (!selectedIds.includes(targetId)) {
-      //   selectedIds.push(targetId);
-      // } else {
-      //   selectedIds.splice(selectedIds.indexOf(targetId), 1);
-      // }
 
       drawing.dispatchEvent(
         new CustomEvent("changeSelectedNodes", {

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -121,10 +121,19 @@ export default defineComponent({
     });
 
     function updateCheckedNodes(node) {
-      const { id, ...obj } = node;
-      state.checkedNodes.has(id)
-        ? state.checkedNodes.delete(id)
-        : state.checkedNodes.set(id, { id, ...obj });
+      console.log(params.data._object.data);
+      const targetData = params.data._object.data.find(
+        (d) => d.__togostanza_id__ === node.__togostanza_id__
+      );
+      console.log(targetData);
+      const { __togostanza_id__, ...obj } = targetData;
+      state.checkedNodes.has(__togostanza_id__)
+        ? state.checkedNodes.delete(__togostanza_id__)
+        : state.checkedNodes.set(__togostanza_id__, {
+            __togostanza_id__,
+            ...obj,
+          });
+      console.log(state.checkedNodes);
       // TODO: add event handler
       // console.log([...state.checkedNodes.values()]);
     }

--- a/stanzas/column-tree/app.vue
+++ b/stanzas/column-tree/app.vue
@@ -121,11 +121,9 @@ export default defineComponent({
     });
 
     function updateCheckedNodes(node) {
-      console.log(params.data._object.data);
       const targetData = params.data._object.data.find(
         (d) => d.__togostanza_id__ === node.__togostanza_id__
       );
-      console.log(targetData);
       const { __togostanza_id__, ...obj } = targetData;
       state.checkedNodes.has(__togostanza_id__)
         ? state.checkedNodes.delete(__togostanza_id__)
@@ -133,9 +131,6 @@ export default defineComponent({
             __togostanza_id__,
             ...obj,
           });
-      console.log(state.checkedNodes);
-      // TODO: add event handler
-      // console.log([...state.checkedNodes.values()]);
     }
     function getChildNodes([layer, parentId]) {
       state.highligthedNodes[layer - 1] = parentId;

--- a/stanzas/column-tree/index.js
+++ b/stanzas/column-tree/index.js
@@ -40,11 +40,6 @@ export default class ColumnTree extends MetaStanza {
         selectedIds.includes(d.__togostanza_id__)
       );
 
-      if (targetElements.length === 0) {
-        this._component.state.checkedNodes = new Map();
-        return;
-      }
-
       const targetElement = targetElements.find(
         (el) => el.__togostanza_id__ === targetId
       );

--- a/stanzas/column-tree/index.js
+++ b/stanzas/column-tree/index.js
@@ -31,8 +31,8 @@ export default class ColumnTree extends MetaStanza {
   }
 
   handleEvent(event) {
+    const { dataUrl, selectedIds } = event.detail;
     if (this.params["event-incoming_change_selected_nodes"]) {
-      const selectedIds = event.detail;
       const targetElements =
         this.element.shadowRoot.querySelectorAll("input.selectable");
 

--- a/stanzas/column-tree/index.js
+++ b/stanzas/column-tree/index.js
@@ -27,26 +27,59 @@ export default class ColumnTree extends MetaStanza {
 
     this._app?.unmount();
     this._app = createApp(App, { ...camelCaseParams, root });
-    this._app.mount(root);
+    this._component = this._app.mount(root);
   }
 
   handleEvent(event) {
-    const { dataUrl, selectedIds } = event.detail;
-    if (this.params["event-incoming_change_selected_nodes"]) {
-      const targetElements =
-        this.element.shadowRoot.querySelectorAll("input.selectable");
-
-      for (const el of targetElements) {
-        const targetTogostanzaId = +el.dataset.togostanzaId;
-        const isSelected = selectedIds.includes(targetTogostanzaId);
-        const inputElement = this.element.shadowRoot.querySelector(
-          `input[data-togostanza-id="${targetTogostanzaId}"]`
-        );
-
-        if (isSelected !== inputElement.checked) {
-          inputElement.click();
-        }
+    const { dataUrl, targetId, selectedIds } = event.detail;
+    if (
+      this.params["event-incoming_change_selected_nodes"] &&
+      event.srcElement !== this.element
+    ) {
+      const targetElements = this._data.filter((d) =>
+        selectedIds.includes(d.__togostanza_id__)
+      );
+      console.log(targetElements);
+      if (targetElements.length === 0) {
+        this._component.state.checkedNodes = new Map();
+        return;
       }
+
+      const targetElement = targetElements.find(
+        (el) => el.__togostanza_id__ === targetId
+      );
+
+      // for (const el of targetElements) {
+      const isSelected = selectedIds.includes(targetId);
+      // const inputElement = this.element.shadowRoot.querySelector(
+      //   `input[data-togostanza-id="${targetTogostanzaId}"]`
+      // );
+
+      // if (!this._component.state.checkedNodes.has(el.id)) {
+      //   // inputElement.click();
+      //   this._component.state.checkedNodes.set(el.id, { id: el.id, ...el });
+      // }
+      console.log(
+        isSelected && !this._component.state.checkedNodes.has(targetId)
+      );
+      console.log(
+        !isSelected && this._component.state.checkedNodes.has(targetId)
+      );
+      if (isSelected && !this._component.state.checkedNodes.has(targetId)) {
+        this._component.state.checkedNodes.set(targetId, {
+          __togostanza_id__: targetId,
+          ...targetElement,
+        });
+      } else if (
+        !isSelected &&
+        this._component.state.checkedNodes.has(targetId)
+      ) {
+        this._component.state.checkedNodes.delete(targetId);
+      }
+      // this._component.state.checkedNodes.includes(el.id)
+      //   ? this._component.state.checkedNodes.delete(el.id)
+      //   : this._component.state.checkedNodes.set(el.id, { id: el.id, ...el });
+      // }
     }
   }
 }

--- a/stanzas/column-tree/index.js
+++ b/stanzas/column-tree/index.js
@@ -39,7 +39,7 @@ export default class ColumnTree extends MetaStanza {
       const targetElements = this._data.filter((d) =>
         selectedIds.includes(d.__togostanza_id__)
       );
-      console.log(targetElements);
+
       if (targetElements.length === 0) {
         this._component.state.checkedNodes = new Map();
         return;
@@ -49,37 +49,19 @@ export default class ColumnTree extends MetaStanza {
         (el) => el.__togostanza_id__ === targetId
       );
 
-      // for (const el of targetElements) {
       const isSelected = selectedIds.includes(targetId);
-      // const inputElement = this.element.shadowRoot.querySelector(
-      //   `input[data-togostanza-id="${targetTogostanzaId}"]`
-      // );
 
-      // if (!this._component.state.checkedNodes.has(el.id)) {
-      //   // inputElement.click();
-      //   this._component.state.checkedNodes.set(el.id, { id: el.id, ...el });
-      // }
-      console.log(
-        isSelected && !this._component.state.checkedNodes.has(targetId)
-      );
-      console.log(
-        !isSelected && this._component.state.checkedNodes.has(targetId)
-      );
-      if (isSelected && !this._component.state.checkedNodes.has(targetId)) {
-        this._component.state.checkedNodes.set(targetId, {
+      const { checkedNodes } = this._component.state;
+      const nodeExists = checkedNodes.has(targetId);
+
+      if (isSelected && !nodeExists) {
+        checkedNodes.set(targetId, {
           __togostanza_id__: targetId,
           ...targetElement,
         });
-      } else if (
-        !isSelected &&
-        this._component.state.checkedNodes.has(targetId)
-      ) {
-        this._component.state.checkedNodes.delete(targetId);
+      } else if (!isSelected && nodeExists) {
+        checkedNodes.delete(targetId);
       }
-      // this._component.state.checkedNodes.includes(el.id)
-      //   ? this._component.state.checkedNodes.delete(el.id)
-      //   : this._component.state.checkedNodes.set(el.id, { id: el.id, ...el });
-      // }
     }
   }
 }

--- a/stanzas/piechart/index.ts
+++ b/stanzas/piechart/index.ts
@@ -148,7 +148,7 @@ export default class Piechart extends MetaStanza {
       updateSelectedElementClassNameForD3.apply(null, [
         {
           drawing: this._chartArea,
-          selectedIds: event.detail,
+          selectedIds: event.detail.selectedIds,
           ...this.selectedEventParams,
         },
       ]);

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -58,7 +58,7 @@ export default class Sunburst extends MetaStanza {
       updateSelectedElementClassNameForD3.apply(null, [
         {
           drawing: this._chartArea,
-          selectedIds: event.detail,
+          selectedIds: event.detail.selectedIds,
           ...this.selectedEventParams,
         },
       ]);

--- a/stanzas/tree/index.js
+++ b/stanzas/tree/index.js
@@ -722,7 +722,7 @@ export default class Tree extends MetaStanza {
     if (this.params["event-incoming_change_selected_nodes"]) {
       updateSelectedElementClassNameForD3.apply(null, [
         {
-          selectedIds: event.detail,
+          selectedIds: event.detail.selectedIds,
           ...this.selectedEventParams,
         },
       ]);

--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -111,7 +111,7 @@ export default class TreeMapStanza extends MetaStanza {
       updateSelectedElementClassNameForD3.apply(null, [
         {
           drawing: this._chartArea,
-          selectedIds: event.detail,
+          selectedIds: event.detail.selectedIds,
           ...this.selectedEventParams,
         },
       ]);


### PR DESCRIPTION
- column treeのcheckbox状態管理を変えましたので、UIにないときにもチェック状態が更新されています。
- ユーザーが今選択したidの情報を渡せるように、`CustomEvent`の`detail`をobjectにしました。（`dataUrl`を追加したが何も機能していません）