### PR TITLE
fix tree graphs bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,30 +147,16 @@ export function checkIfHexColor(text) {
 }
 
 export function emitSelectedEventForD3({
-  drawing,
   rootElement = undefined,
+  selectedIds,
   targetId,
-  targetElementSelector,
-  selectedElementSelector,
-  idPath,
   dataUrl,
 }) {
-  // get filter nodes
-  const targetElements = drawing.selectAll(targetElementSelector);
-
-  const selectedElements = targetElements.filter(selectedElementSelector);
-
-  const selectedIds = selectedElements.data().map((d) => {
-    const id = get(d, idPath);
-    return id;
-  });
-
   if (!selectedIds.includes(targetId)) {
     selectedIds.push(targetId);
   } else {
     selectedIds.splice(selectedIds.indexOf(targetId), 1);
   }
-
   rootElement.dispatchEvent(
     new CustomEvent("changeSelectedNodes", {
       detail: { targetId, selectedIds, dataUrl },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,11 +152,10 @@ export function emitSelectedEventForD3({
   targetId,
   dataUrl,
 }) {
-  if (!selectedIds.includes(targetId)) {
-    selectedIds.push(targetId);
-  } else {
-    selectedIds.splice(selectedIds.indexOf(targetId), 1);
-  }
+  !selectedIds.includes(targetId)
+    ? selectedIds.push(targetId)
+    : selectedIds.splice(selectedIds.indexOf(targetId), 1);
+
   rootElement.dispatchEvent(
     new CustomEvent("changeSelectedNodes", {
       detail: { targetId, selectedIds, dataUrl },
@@ -171,13 +170,12 @@ export function updateSelectedElementClassNameForD3({
   selectedElementClassName,
   idPath,
 }) {
-  const targetElements = drawing.selectAll(targetElementSelector);
-
-  targetElements.classed(selectedElementClassName, (d) => {
-    const targetId = get(d, idPath);
-
-    return selectedIds.indexOf(targetId) !== -1;
-  });
+  drawing
+    .selectAll(targetElementSelector)
+    .classed(selectedElementClassName, (d) => {
+      const targetId = get(d, idPath);
+      return selectedIds.indexOf(targetId) !== -1;
+    });
 }
 
 // TODO update utils.d.ts and JSDoc

--- a/stanzas/column-tree/NodeColumn.vue
+++ b/stanzas/column-tree/NodeColumn.vue
@@ -111,11 +111,13 @@ export default defineComponent({
     function handleCheckboxClick(node) {
       setCheckedNode(node);
 
-      const drawing = document.querySelector("togostanza-column-tree");
-
-      drawing.dispatchEvent(
+      document.querySelector("togostanza-column-tree").dispatchEvent(
         new CustomEvent("changeSelectedNodes", {
-          detail: { selectedIds: [...this.checkedNodes.keys()], dataUrl: "" },
+          detail: {
+            selectedIds: [...this.checkedNodes.keys()],
+            targetId: node.__togostanza_id__,
+            dataUrl: "",
+          },
         })
       );
     }

--- a/stanzas/piechart/metadata.json
+++ b/stanzas/piechart/metadata.json
@@ -129,7 +129,7 @@
     {
       "stanza:key": "--togostanza-theme-selected_border_color",
       "stanza:type": "color",
-      "stanza:default": "#FFEE00",
+      "stanza:default": "#FF0000",
       "stanza:description": "Color applied to the selected item"
     },
     {

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -533,10 +533,10 @@ export default class Sunburst extends MetaStanza {
           .on("click", (e, d) => {
             if (e.detail === 1) {
               timeout = setTimeout(() => {
-                stanza.selectedIds = [
-                  ...stanza.selectedIds,
-                  d.data.data.__togostanza_id__,
-                ];
+                // stanza.selectedIds = [
+                //   ...stanza.selectedIds,
+                //   d.data.data.__togostanza_id__,
+                // ];
 
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -538,10 +538,6 @@ export default class Sunburst extends MetaStanza {
                 const selectedIds = stanza.selectedIds;
                 const targetId = d.data.data.__togostanza_id__;
 
-                // !stanza.selectedIds.includes(targetId)
-                //   ? stanza.selectedIds.push(targetId)
-                //   : stanza.selectedIds.splice(selectedIds.indexOf(targetId), 1);
-
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,
                   rootElement: stanza.element,

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -537,7 +537,7 @@ export default class Sunburst extends MetaStanza {
                   ...stanza.selectedIds,
                   d.data.data.__togostanza_id__,
                 ];
-                console.log(stanza.selectedIds);
+
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,
                   rootElement: stanza.element,

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -322,6 +322,7 @@ export default class Sunburst extends MetaStanza {
     let timeout;
 
     path
+      .filter((d) => d.children)
       .style("cursor", "pointer")
       .on("click", (e, d) => {
         if (e.detail === 1) {
@@ -335,7 +336,6 @@ export default class Sunburst extends MetaStanza {
           }, 500);
         }
       })
-      .filter((d) => d.children)
       .on("dblclick", (e, d) => {
         clearTimeout(timeout);
         clicked(e, d);
@@ -378,7 +378,23 @@ export default class Sunburst extends MetaStanza {
       .attr("pointer-events", "all")
       .on("dblclick", (e, d) => {
         clearTimeout(timeout);
-        clicked(e, d);
+        clicked(e, d.parent);
+      })
+      .on("click", (e, d) => {
+        const isBlankRoot = Boolean(d.current.children);
+        if (isBlankRoot) {
+          return;
+        }
+        if (e.detail === 1) {
+          timeout = setTimeout(() => {
+            return emitSelectedEventForD3({
+              drawing: this._chartArea,
+              rootElement: this.element,
+              targetId: d.data.data.__togostanza_id__,
+              ...this.selectedEventParams,
+            });
+          }, 500);
+        }
       });
 
     //Text labels
@@ -435,7 +451,7 @@ export default class Sunburst extends MetaStanza {
         return;
       }
 
-      parent.datum(p.parent || root);
+      parent.datum(p.parent ? p : root);
 
       parent.attr("cursor", (d) => (d === root ? "auto" : "pointer"));
 

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -29,6 +29,7 @@ let path;
 
 export default class Sunburst extends MetaStanza {
   _chartArea;
+  selectedIds;
   selectedEventParams = {
     targetElementSelector: "g path.selectable",
     selectedElementClassName: "-selected",
@@ -532,6 +533,9 @@ export default class Sunburst extends MetaStanza {
           .on("click", (e, d) => {
             if (e.detail === 1) {
               timeout = setTimeout(() => {
+                stanza.selectedIds =
+                  [...stanza.selectedIds, d.data.data.__togostanza_id__] ?? [];
+                console.log(stanza.selectedIds);
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,
                   rootElement: stanza.element,

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -55,6 +55,8 @@ export default class Sunburst extends MetaStanza {
 
   handleEvent(event) {
     if (this.params["event-incoming_change_selected_nodes"]) {
+      const { selectedIds } = event.detail;
+      this.selectedIds = selectedIds;
       updateSelectedElementClassNameForD3.apply(null, [
         {
           drawing: this._chartArea,
@@ -533,16 +535,18 @@ export default class Sunburst extends MetaStanza {
           .on("click", (e, d) => {
             if (e.detail === 1) {
               timeout = setTimeout(() => {
-                // stanza.selectedIds = [
-                //   ...stanza.selectedIds,
-                //   d.data.data.__togostanza_id__,
-                // ];
+                const selectedIds = stanza.selectedIds;
+                const targetId = d.data.data.__togostanza_id__;
+
+                // !stanza.selectedIds.includes(targetId)
+                //   ? stanza.selectedIds.push(targetId)
+                //   : stanza.selectedIds.splice(selectedIds.indexOf(targetId), 1);
 
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,
                   rootElement: stanza.element,
-                  targetId: d.data.data.__togostanza_id__,
-                  selectedIds: stanza.selectedIds,
+                  targetId,
+                  selectedIds,
                   ...stanza.selectedEventParams,
                 });
               }, 500);

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -29,11 +29,10 @@ let path;
 
 export default class Sunburst extends MetaStanza {
   _chartArea;
-  selectedIds;
+  selectedIds = [];
   selectedEventParams = {
     targetElementSelector: "g path.selectable",
     selectedElementClassName: "-selected",
-    selectedElementSelector: ".-selected",
     idPath: "data.data.__togostanza_id__",
   };
 
@@ -330,9 +329,9 @@ export default class Sunburst extends MetaStanza {
         if (e.detail === 1) {
           timeout = setTimeout(() => {
             return emitSelectedEventForD3({
-              drawing: this._chartArea,
               rootElement: this.element,
               targetId: d.data.data.__togostanza_id__,
+              selectedIds: this.selectedIds,
               ...this.selectedEventParams,
             });
           }, 500);
@@ -533,13 +532,16 @@ export default class Sunburst extends MetaStanza {
           .on("click", (e, d) => {
             if (e.detail === 1) {
               timeout = setTimeout(() => {
-                stanza.selectedIds =
-                  [...stanza.selectedIds, d.data.data.__togostanza_id__] ?? [];
+                stanza.selectedIds = [
+                  ...stanza.selectedIds,
+                  d.data.data.__togostanza_id__,
+                ];
                 console.log(stanza.selectedIds);
                 return emitSelectedEventForD3({
                   drawing: stanza._chartArea,
                   rootElement: stanza.element,
                   targetId: d.data.data.__togostanza_id__,
+                  selectedIds: stanza.selectedIds,
                   ...stanza.selectedEventParams,
                 });
               }, 500);

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -59,6 +59,7 @@ export default class Sunburst extends MetaStanza {
         {
           drawing: this._chartArea,
           selectedIds: event.detail.selectedIds,
+          targetId: event.detail.targetId,
           ...this.selectedEventParams,
         },
       ]);

--- a/stanzas/sunburst/index.js
+++ b/stanzas/sunburst/index.js
@@ -322,7 +322,6 @@ export default class Sunburst extends MetaStanza {
     let timeout;
 
     path
-      .filter((d) => d.children)
       .style("cursor", "pointer")
       .on("click", (e, d) => {
         if (e.detail === 1) {
@@ -336,6 +335,7 @@ export default class Sunburst extends MetaStanza {
           }, 500);
         }
       })
+      .filter((d) => d.children)
       .on("dblclick", (e, d) => {
         clearTimeout(timeout);
         clicked(e, d);

--- a/stanzas/sunburst/metadata.json
+++ b/stanzas/sunburst/metadata.json
@@ -165,7 +165,7 @@
     {
       "stanza:key": "--togostanza-theme-selected_border_color",
       "stanza:type": "color",
-      "stanza:default": "#FFEE00",
+      "stanza:default": "#FF0000",
       "stanza:description": "Color applied to the selected item"
     },
     {

--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -218,9 +218,6 @@ function draw(el, dataset, opts, stanza) {
 
     let timeout;
     node
-      .filter((d) => {
-        return d === root ? d.parent : d.children;
-      })
       .attr("cursor", "pointer")
       .on("click", (e, d) => {
         if (e.detail === 1) {
@@ -233,6 +230,9 @@ function draw(el, dataset, opts, stanza) {
             });
           }, 500);
         }
+      })
+      .filter((d) => {
+        return d === root ? d.parent : d.children;
       })
       .on("dblclick", (e, d) => {
         clearTimeout(timeout);

--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -112,6 +112,7 @@ export default class TreeMapStanza extends MetaStanza {
         {
           drawing: this._chartArea,
           selectedIds,
+          targetId: event.detail.targetId,
           ...this.selectedEventParams,
         },
       ]);

--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -28,13 +28,12 @@ import {
 
 export default class TreeMapStanza extends MetaStanza {
   _chartArea;
+  selectedIds = [];
   selectedEventParams = {
     targetElementSelector: "g rect.selectable",
     selectedElementClassName: "-selected",
-    selectedElementSelector: ".-selected",
     idPath: "data.data.__togostanza_id__",
   };
-  selectedIds;
 
   menu() {
     return [
@@ -226,6 +225,7 @@ function draw(el, dataset, opts, stanza) {
               drawing: stanza._chartArea,
               rootElement: stanza.element,
               targetId: d.data.data.__togostanza_id__,
+              selectedIds: stanza.selectedIds,
               ...stanza.selectedEventParams,
             });
           }, 500);
@@ -241,7 +241,7 @@ function draw(el, dataset, opts, stanza) {
         updateSelectedElementClassNameForD3.apply(stanza, [
           {
             drawing: stanza._chartArea,
-            selectedIds: stanza.selectedIds ?? [],
+            selectedIds: stanza.selectedIds,
             ...stanza.selectedEventParams,
           },
         ]);

--- a/stanzas/treemap/metadata.json
+++ b/stanzas/treemap/metadata.json
@@ -136,7 +136,7 @@
     {
       "stanza:key": "--togostanza-theme-selected_border_color",
       "stanza:type": "color",
-      "stanza:default": "blue",
+      "stanza:default": "#FF0000",
       "stanza:description": "Color applied to the selected item"
     },
     {


### PR DESCRIPTION
確認したところ、選択連携の動きは問題なさそうです。
今sunburstのcenter部分のハイライトはうまく表示を分けられてないです。