### PR TITLE
add apiError func

### DIFF
--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -1,0 +1,122 @@
+import ToolTip from "./ToolTip.js";
+import Legend from "./Legend2.js";
+
+/**
+ * Represents the data needed to handle an API error.
+ */
+interface StanzaData {
+  _main: HTMLElement;
+  _apiError: boolean;
+  root: HTMLElement;
+}
+
+/**
+ * Represents an item in the legend.
+ */
+interface LegendItem {
+  id: number;
+  color: string;
+  value: number;
+}
+
+/**
+ * Represents the configuration for the legend.
+ */
+interface LegendConfiguration {
+  items: LegendItem[];
+  title: string;
+  options: {
+    shape: string;
+  };
+}
+
+/**
+ * Represents the options for displaying the legend.
+ */
+interface LegendOptions {
+  isLegendVisible: boolean;
+  legendConfiguration: LegendConfiguration;
+}
+
+/**
+ * Handles API errors by displaying an error message or rendering the content.
+ * Also manages legend and tooltip based on the configuration.
+ * @param stanzaData - Data related to the stanza.
+ * @param drawContent - A function to draw content if there is no error.
+ * @param hasLegend - Indicates if the legend should be displayed.
+ * @param hasTooltip - Indicates if the tooltip should be displayed.
+ * @param legendOptions - Configuration options for the legend.
+ */
+export function handleApiError(
+  stanzaData: StanzaData,
+  drawContent: () => void,
+  hasLegend = false,
+  hasTooltip = false,
+  legendOptions: LegendOptions
+): void {
+  const { _main: main, _apiError: apiError, root } = stanzaData;
+  const { isLegendVisible, legendConfiguration } = legendOptions;
+
+  handleErrorMessage(apiError, main);
+  if (!apiError) {
+    drawContent();
+  }
+  if (hasLegend) {
+    manageLegend(isLegendVisible, legendConfiguration, root, apiError);
+  }
+  if (hasTooltip) {
+    manageTooltip(main);
+  }
+}
+
+/**
+ * Displays or removes an error message based on the API error status.
+ * @param apiError - Indicates if there is an API error.
+ * @param main - The main HTML element to display the error message.
+ */
+function handleErrorMessage(apiError: boolean, main: HTMLElement): void {
+  const errorMessageEl = main.querySelector(".metastanza-error-message-div");
+
+  if (apiError) {
+    if (!errorMessageEl) {
+      const errorMessageDiv = document.createElement("div");
+      errorMessageDiv.className = "metastanza-error-message-div";
+      errorMessageDiv.textContent = "Please fill in the exact data-url";
+      main.appendChild(errorMessageDiv);
+    }
+  } else {
+    errorMessageEl?.remove();
+  }
+}
+
+/**
+ * Manages the display of the legend based on the given parameters.
+ * @param isShow - Determines whether the legend should be displayed.
+ * @param config - The configuration for the legend.
+ * @param root - The root HTML element where the legend will be displayed.
+ * @param apiError - Indicates if there is an API error.
+ */
+function manageLegend(isShow: boolean, config: LegendConfiguration, root: HTMLElement, apiError: boolean): void {
+  const legendElement = root.querySelector("togostanza--legend2");
+  if (!isShow || apiError) {
+    legendElement?.remove();
+  } else if (!legendElement) {
+    const legend = new Legend();
+    root.append(legend);
+    legend.setup(config);
+  }
+}
+
+/**
+ * Manages the tooltip by removing any existing tooltip and creating a new one if necessary.
+ * @param main - The main HTML element where the tooltip will be displayed.
+ */
+function manageTooltip(main: HTMLElement): void {
+  const tooltipElement = main.querySelector("togostanza--tooltip");
+  tooltipElement?.remove();
+  if (!tooltipElement) {
+    const tooltip = new ToolTip();
+    main.append(tooltip);
+    tooltip.setup(main.querySelectorAll("[data-tooltip]"));
+  }
+}

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -2,12 +2,29 @@ import ToolTip from "./ToolTip.js";
 import Legend from "./Legend2.js";
 
 /**
+ * Options for handling API errors in the visualization.
+ * @interface
+ * @property {StanzaData} stanzaData - The data of the current stanza.
+ * @property {() => void} drawContent - A function to draw the content of the stanza.
+ * @property {boolean} hasLegend - Indicates whether the legend should be displayed.
+ * @property {boolean} hasTooltip - Indicates whether tooltips should be displayed.
+ * @property {LegendOptions} legendOptions - Configuration options for the legend.
+ */
+interface HandleApiErrorOptions {
+  stanzaData: StanzaData;
+  drawContent: () => void;
+  hasLegend: boolean;
+  hasTooltip: boolean;
+  legendOptions: LegendOptions; // または適切な型
+}
+
+/**
  * Represents the data needed to handle an API error.
  */
 interface StanzaData {
   _main: HTMLElement;
   _apiError: boolean;
-  root: HTMLElement;
+  root: ShadowRoot;
 }
 
 /**
@@ -41,19 +58,9 @@ interface LegendOptions {
 /**
  * Handles API errors by displaying an error message or rendering the content.
  * Also manages legend and tooltip based on the configuration.
- * @param stanzaData - Data related to the stanza.
- * @param drawContent - A function to draw content if there is no error.
- * @param hasLegend - Indicates if the legend should be displayed.
- * @param hasTooltip - Indicates if the tooltip should be displayed.
- * @param legendOptions - Configuration options for the legend.
  */
-export function handleApiError(
-  stanzaData: StanzaData,
-  drawContent: () => void,
-  hasLegend = false,
-  hasTooltip = false,
-  legendOptions: LegendOptions
-): void {
+export function handleApiError(options: HandleApiErrorOptions) {
+  const { stanzaData, drawContent, hasLegend, hasTooltip, legendOptions } = options;
   const { _main: main, _apiError: apiError, root } = stanzaData;
   const { isLegendVisible, legendConfiguration } = legendOptions;
 
@@ -74,7 +81,7 @@ export function handleApiError(
  * @param apiError - Indicates if there is an API error.
  * @param main - The main HTML element to display the error message.
  */
-function handleErrorMessage(apiError: boolean, main: HTMLElement): void {
+function handleErrorMessage(apiError: boolean, main: HTMLElement) {
   const errorMessageEl = main.querySelector(".metastanza-error-message-div");
 
   if (apiError) {
@@ -96,7 +103,12 @@ function handleErrorMessage(apiError: boolean, main: HTMLElement): void {
  * @param root - The root HTML element where the legend will be displayed.
  * @param apiError - Indicates if there is an API error.
  */
-function manageLegend(isShow: boolean, config: LegendConfiguration, root: HTMLElement, apiError: boolean): void {
+function manageLegend(
+  isShow: boolean,
+  config: LegendConfiguration,
+  root: ShadowRoot,
+  apiError: boolean
+): void {
   const legendElement = root.querySelector("togostanza--legend2");
   if (!isShow || apiError) {
     legendElement?.remove();

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -60,7 +60,8 @@ interface LegendOptions {
  * Also manages legend and tooltip based on the configuration.
  */
 export function handleApiError(options: HandleApiErrorOptions) {
-  const { stanzaData, drawContent, hasLegend, hasTooltip, legendOptions } = options;
+  const { stanzaData, drawContent, hasLegend, hasTooltip, legendOptions } =
+    options;
   const { _main: main, _apiError: apiError, root } = stanzaData;
   const { isLegendVisible, legendConfiguration } = legendOptions;
 
@@ -108,7 +109,7 @@ function manageLegend(
   config: LegendConfiguration,
   root: ShadowRoot,
   apiError: boolean
-): void {
+) {
   const legendElement = root.querySelector("togostanza--legend2");
   if (!isShow || apiError) {
     legendElement?.remove();
@@ -123,7 +124,7 @@ function manageLegend(
  * Manages the tooltip by removing any existing tooltip and creating a new one if necessary.
  * @param main - The main HTML element where the tooltip will be displayed.
  */
-function manageTooltip(main: HTMLElement): void {
+function manageTooltip(main: HTMLElement) {
   const tooltipElement = main.querySelector("togostanza--tooltip");
   tooltipElement?.remove();
   if (!tooltipElement) {

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -6,16 +6,16 @@ import Legend from "./Legend2.js";
  * @interface
  * @property {StanzaData} stanzaData - The data of the current stanza.
  * @property {() => void} drawContent - A function to draw the content of the stanza.
- * @property {boolean} hasLegend - Indicates whether the legend should be displayed.
- * @property {boolean} hasTooltip - Indicates whether tooltips should be displayed.
- * @property {LegendOptions} legendOptions - Configuration options for the legend.
+ * @property {boolean} [hasLegend] - Indicates whether the legend should be displayed.
+ * @property {boolean} [hasTooltip] - Indicates whether tooltips should be displayed.
+ * @property {LegendOptions} [legendOptions] - Configuration options for the legend.
  */
 interface HandleApiErrorOptions {
   stanzaData: StanzaData;
   drawContent: () => void;
-  hasLegend: boolean;
-  hasTooltip: boolean;
-  legendOptions: LegendOptions; // または適切な型
+  hasLegend?: boolean;
+  hasTooltip?: boolean;
+  legendOptions?: LegendOptions;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/vue-fontawesome": "^3.0.0-1",
         "@rollup/plugin-replace": "^5.0.1",
         "@types/d3": "^7.4.0",
+        "@types/topojson-specification": "^1.0.5",
         "@vue/compiler-sfc": "^3.2.11",
         "@vueform/slider": "^1.0.3",
         "axios": "^1.1.3",
@@ -2987,7 +2988,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
       "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
-      "dev": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -19351,7 +19351,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
       "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
-      "dev": true,
       "requires": {
         "@types/geojson": "*"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.0-1",
     "@rollup/plugin-replace": "^5.0.1",
     "@types/d3": "^7.4.0",
+    "@types/topojson-specification": "^1.0.5",
     "@vue/compiler-sfc": "^3.2.11",
     "@vueform/slider": "^1.0.3",
     "axios": "^1.1.3",

--- a/stanzas/heatmap/index.js
+++ b/stanzas/heatmap/index.js
@@ -68,7 +68,7 @@ export default class Heatmap extends MetaStanza {
 
     // Legend
     const legendTitle = this.params["legend-title"];
-    const legendShow = this.params["legend-visible"];
+    const isLegendVisible = this.params["legend-visible"];
     const legendGroups = this.params["legend-levels_number"];
     const legendConfiguration = {
       items: intervals(setColor).map((interval) => ({
@@ -209,7 +209,7 @@ export default class Heatmap extends MetaStanza {
     };
 
     const legendOptions = {
-      isLegendVisible: legendShow,
+      isLegendVisible,
       legendConfiguration,
     };
     // Draw content and handle api errors

--- a/stanzas/heatmap/index.ts
+++ b/stanzas/heatmap/index.ts
@@ -220,6 +220,7 @@ export default class Heatmap extends MetaStanza {
             {
               drawing: this._chartArea,
               rootElement: this.element,
+              dataUrl: this.params["data-url"],
               targetId: d["__togostanza_id__"],
               selectedIds: this.selectedIds,
               ...this.selectedEventParams,

--- a/stanzas/named-map/index.ts
+++ b/stanzas/named-map/index.ts
@@ -1,13 +1,14 @@
 import MetaStanza from "../../lib/MetaStanza";
 import { select, json, geoMercator, geoAlbersUsa, geoPath } from "d3";
 import { feature } from "topojson-client";
+import { Feature, Geometry } from "geojson";
+import { Topology } from "topojson-specification";
 import {
   emitSelectedEvent,
   updateSelectedElementClassNameForD3,
-} from "@/lib/utils";
-import ToolTip from "@/lib/ToolTip";
-import Legend from "@/lib/Legend2";
-import { getGradationColor } from "@/lib/ColorGenerator";
+} from "../../lib/utils";
+import { handleApiError } from "../../lib/apiError";
+import { getGradationColor } from "../../lib/ColorGenerator";
 import {
   downloadSvgMenuItem,
   downloadPngMenuItem,
@@ -15,6 +16,16 @@ import {
   downloadCSVMenuItem,
   downloadTSVMenuItem,
 } from "togostanza-utils";
+
+interface DataItem {
+  [key: string]: string | number;
+  __togostanza_id: string | number;
+}
+
+interface CustomFeature extends Feature<Geometry> {
+  rate?: string | number;
+  __togostanza_id__?: string | number;
+}
 
 const REGION = new Map([
   [
@@ -38,6 +49,8 @@ const REGION = new Map([
 ]);
 
 export default class regionGeographicMap extends MetaStanza {
+  _chartArea: d3.Selection<SVGGElement, unknown, SVGElement, undefined>;
+  selectedIds: Array<string | number> = [];
   selectedEventParams = {
     targetElementSelector: ".path",
     selectedElementClassName: "-selected",
@@ -59,58 +72,46 @@ export default class regionGeographicMap extends MetaStanza {
     const root = this._main;
     const dataset = this._data;
     this._chartArea = select(root.querySelector("svg"));
-    this.selectedIds = []
+    this.selectedIds = [];
 
     // Parameters
-    const region = this.params["data-region"];
-    const objectType = this.params["data-layer"].trim();
-    const userTopoJson = this.params["data-user_topojson"].trim();
+    const region: string = this.params["data-region"];
+    const objectType: string = this.params["data-layer"].trim();
+    const userTopoJson: string = this.params["data-user_topojson"].trim();
     if (userTopoJson) {
       REGION.set("user", { url: userTopoJson });
     } else {
       REGION.delete("user");
     }
 
-    const [property1, property2] = this.params["data-property"]
+    const [property1, property2]: [string, string] = this.params[
+      "data-property"
+    ]
       .trim()
       .split(/[.,-_/;。、 ]+/);
-    const switchProperty = (datum) =>
+    const switchProperty = (datum: CustomFeature) =>
       property2 ? datum[property1][property2] : datum[property1];
 
-    const legendVisible = this.params["legend-visible"];
-    const legendTitle = this.params["legend-title"];
-    const legendLevelsNumber = parseFloat(this.params["legend-levels_number"]);
-
-    const tooltipKey = this.params["tooltips-key"].trim();
-    if (!this.tooltip) {
-      this.tooltip = new ToolTip();
-      root.append(this.tooltip);
-    }
-    if (this._apiError) {
-      this.legend?.remove();
-      this.legend = null;
-      this.tooltip?.remove();
-      this.tooltip = null;
-    }
-
     // Color scale
-    const areaColorKey = this.params["area-color_key"].trim();
-    const areaColorValue = this.params["area-color_value"].trim();
-    const areaColorMin = this.params["area-color_min"];
-    const areaColorMid = this.params["area-color_mid"];
-    const areaColorMax = this.params["area-color_max"];
+    const areaColorKey: string = this.params["area-color_key"].trim();
+    const areaColorValue: string = this.params["area-color_value"].trim();
+    const areaColorMin: string = this.params["area-color_min"];
+    const areaColorMid: string = this.params["area-color_mid"];
+    const areaColorMax: string = this.params["area-color_max"];
     let areaDomainMin = parseFloat(this.params["area-value_min"]);
     let areaDomainMid = parseFloat(this.params["area-value_mid"]);
     let areaDomainMax = parseFloat(this.params["area-value_max"]);
-    const userDataValue = dataset.map((d) => parseFloat(d[areaColorValue]));
+    const userDataValue = dataset.map((d: DataItem) => {
+      d[areaColorValue];
+    });
 
-    if (isNaN(parseFloat(areaDomainMin))) {
+    if (isNaN(areaDomainMin)) {
       areaDomainMin = Math.min(...userDataValue);
     }
-    if (isNaN(parseFloat(areaDomainMax))) {
+    if (isNaN(areaDomainMax)) {
       areaDomainMax = Math.max(...userDataValue);
     }
-    if (isNaN(parseFloat(areaDomainMid))) {
+    if (isNaN(areaDomainMid)) {
       areaDomainMid = (areaDomainMax + areaDomainMin) / 2;
     }
 
@@ -120,6 +121,24 @@ export default class regionGeographicMap extends MetaStanza {
       [areaDomainMin, areaDomainMid, areaDomainMax]
     );
 
+    // Legend
+    const isLegendVisible = this.params["legend-visible"];
+    const legendTitle = this.params["legend-title"];
+    const legendLevelsNumber = parseFloat(this.params["legend-levels_number"]);
+    const legendConfiguration = {
+      items: intervals(setColor).map((interval) => ({
+        id: interval.label,
+        color: interval.color,
+        value: interval.label,
+      })),
+      title: legendTitle,
+      options: {
+        shape: "square",
+      },
+    };
+
+    const tooltipKey = this.params["tooltips-key"].trim();
+
     //Styles
     const width = parseFloat(this.css("--togostanza-canvas-width"));
     const height = parseFloat(this.css("--togostanza-canvas-height"));
@@ -127,55 +146,52 @@ export default class regionGeographicMap extends MetaStanza {
     const svgWidth = width - padding.LEFT - padding.RIGHT;
     const svgHeight = height - padding.TOP - padding.BOTTOM;
 
-    // Drawing svg
-    select(root).select("svg").remove();
-    this._chartArea = select(root)
-      .append("svg")
-      .attr("width", svgWidth)
-      .attr("height", svgHeight);
-    const g = this._chartArea.append("g").classed("g-path", true);
-
     // for data-layer error
     const existError = root.querySelector(".error");
     if (existError) {
       root.removeChild(existError);
     }
 
-    if (!this._apiError) {
-      // for api error
-      const errorMessageEl = root.querySelector(
-        ".metastanza-error-message-div"
-      );
-      if (errorMessageEl) {
-        errorMessageEl.remove();
-      }
+    if (!this._chartArea.empty()) {
+      this._chartArea.remove();
+    }
+
+    const drawContent = async () => {
+      // Drawing svg
+      this._chartArea = select(root)
+        .append("svg")
+        .attr("width", svgWidth)
+        .attr("height", svgHeight);
+      const g = this._chartArea.append("g").classed("g-path", true);
 
       // Setting  projection
       const projection = region === "us" ? geoAlbersUsa() : geoMercator();
       const path = geoPath().projection(projection);
 
-      let topoJsonType;
+      let topoJsonType: string[] = [];
       try {
         // Combine data
         const areaUrl = REGION.get(region).url;
-        const topoJson = await json(areaUrl);
+        const topoJson: Topology = await json(areaUrl);
         topoJsonType = Object.keys(topoJson.objects);
-        const geoJson = feature(
-          topoJson,
-          topoJson.objects[objectType]
-        ).features;
+        const geoJsonObject = feature(topoJson, topoJson.objects[objectType]);
 
-        const allData = geoJson.map((geoDatum) => {
-          const matchData = dataset.find(
-            (val) => switchProperty(geoDatum) === val[areaColorKey]
-          );
-          return Object.assign({}, geoDatum, {
-            [areaColorValue]: matchData ? matchData[areaColorValue] : undefined,
-            __togostanza_id__: matchData
-              ? matchData.__togostanza_id__
-              : undefined,
+        let allData = [];
+        if ("features" in geoJsonObject) {
+          allData = geoJsonObject.features.map((geoDatum) => {
+            const matchData = dataset.find(
+              (val: DataItem) => switchProperty(geoDatum) === val[areaColorKey]
+            );
+            return Object.assign({}, geoDatum, {
+              [areaColorValue]: matchData
+                ? matchData[areaColorValue]
+                : undefined,
+              __togostanza_id__: matchData
+                ? matchData.__togostanza_id__
+                : undefined,
+            });
           });
-        });
+        }
 
         // Drawing path
         const pathGroup = g
@@ -199,7 +215,8 @@ export default class regionGeographicMap extends MetaStanza {
               {
                 drawing: this._chartArea,
                 rootElement: this.element,
-                targetId: d.__togostanza_id__,
+                dataUrl: this.params["data-url"],
+                targetId: d["__togostanza_id__"],
                 selectedIds: this.selectedIds,
                 ...this.selectedEventParams,
               },
@@ -213,7 +230,7 @@ export default class regionGeographicMap extends MetaStanza {
           ymin = Infinity,
           xmax = -Infinity,
           ymax = -Infinity;
-        paths.forEach((path) => {
+        paths.forEach((path: SVGGraphicsElement) => {
           const bbox = path.getBBox();
           xmin = Math.min(xmin, bbox.x);
           ymin = Math.min(ymin, bbox.y);
@@ -259,32 +276,20 @@ export default class regionGeographicMap extends MetaStanza {
 
         root.prepend(errorElement);
       }
+    };
 
-      // Setting tooltip
-      this.tooltip.setup(root.querySelectorAll("[data-tooltip]"));
-
-      // Setting legend
-      if (legendVisible) {
-        if (!this.legend) {
-          this.legend = new Legend();
-          this.root.append(this.legend);
-        }
-        this.legend.setup({
-          items: intervals(setColor).map((interval) => ({
-            id: interval.label,
-            color: interval.color,
-            value: interval.label,
-          })),
-          title: legendTitle,
-          options: {
-            shape: "square",
-          },
-        });
-      } else {
-        this.legend?.remove();
-        this.legend = null;
-      }
-    }
+    const legendOptions = {
+      isLegendVisible,
+      legendConfiguration,
+    };
+    // Draw content and handle api errors
+    handleApiError({
+      stanzaData: this,
+      drawContent,
+      hasLegend: true,
+      hasTooltip: true,
+      legendOptions,
+    });
 
     //Create legend objects
     function intervals(
@@ -306,7 +311,10 @@ export default class regionGeographicMap extends MetaStanza {
     }
   }
 
-  handleEvent(event) {
+  // TODO: add color type. ScaleLinear<string, number>.
+  // check https://github.com/d3/d3-scale/issues/111, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38574
+  // fix ColorGenerator to typescript
+  handleEvent(event: CustomEvent) {
     if (this.params["event-incoming_change_selected_nodes"]) {
       this.selectedIds = event.detail.selectedIds;
       updateSelectedElementClassNameForD3.apply(null, [


### PR DESCRIPTION
api errorの共通化のためにlb内にapiError.tsを追加しました。
Heatmapで実装をしています。ご確認をお願いします。
@maruk0chan もチェックしていただけると嬉しいです。

内容としては、apiError.ts内の関数handleApiErrorをstanzaに追加します。
引数は
- `stanzaData`: 各stanzaのthisを渡します。
- `drawContent`: aipErrorではない場合の描画内容の関数です。 stanza内でconstで括ってます。
- `hasLegend`: legendを描画するstanzaであればtrue
- `hasTooltip`: tooltipを描画するstanzaであればtrue
- `lgendObtions`: legendに関するoptionのObjectです。