### PR TITLE
add padding to treemap

### DIFF
--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -185,12 +185,18 @@ function draw(el, dataset, opts, stanza) {
         })
     );
 
+  const SVG_PADDING = 5; // TODO check if this should be one of the parameters
   select(el).select("svg").remove();
   stanza._chartArea = select(el)
     .append("svg")
-    .attr("width", WIDTH)
-    .attr("height", HEIGHT)
-    .attr("viewBox", [0, 0, WIDTH, HEIGHT]);
+    .attr("width", WIDTH + SVG_PADDING * 2)
+    .attr("height", HEIGHT + SVG_PADDING * 2)
+    .attr("viewBox", [
+      -SVG_PADDING,
+      -SVG_PADDING,
+      WIDTH + SVG_PADDING * 2,
+      HEIGHT + SVG_PADDING * 2,
+    ]);
 
   let group = stanza._chartArea.append("g").call(render, treemap(nested), null);
 


### PR DESCRIPTION
Before
<img src='https://github.com/togostanza/metastanza-devel/assets/104617343/8ecf4285-eb88-4e64-b54b-e7d0fb58428a' width='300'>

After
<img src='https://github.com/togostanza/metastanza-devel/assets/104617343/b6f69fa5-3a99-44bd-8da0-4805432a0ac7' width='300'>

svgの一番下が表示できるように、paddingを追加しました。