### PR TITLE
一部URLの追加

### DIFF
--- a/lib/prepareGraphData.js
+++ b/lib/prepareGraphData.js
@@ -9,6 +9,7 @@ const targetNodeSym = Symbol("targetNode");
 const nodeSizeSym = Symbol("nodeSize");
 const nodeColorSym = Symbol("nodeColor");
 const nodeLabelSym = Symbol("nodeLabel");
+const nodeUrlSym = Symbol("nodeUrl");
 const nodeBorderColorSym = Symbol("nodeBorderColor");
 const edgeColorSym = Symbol("edgeColor");
 const idSym = Symbol("id");
@@ -24,6 +25,7 @@ const symbols = {
   groupSym,
   edgeColorSym,
   nodeLabelSym,
+  nodeUrlSym,
   idSym,
   nodeBorderColorSym,
   isPairEdge,
@@ -143,6 +145,7 @@ export default function (nodesC, edgesC, params) {
   if (nodesC.some((d) => d[nodeLabelParams.dataKey])) {
     nodesC.forEach((node) => {
       node[symbols.nodeLabelSym] = node[nodeLabelParams.dataKey] || null;
+      node[symbols.nodeUrlSym] = node[nodeLabelParams.url] || null;
     });
   }
 

--- a/lib/prepareGraphData.js
+++ b/lib/prepareGraphData.js
@@ -145,7 +145,7 @@ export default function (nodesC, edgesC, params) {
   if (nodesC.some((d) => d[nodeLabelParams.dataKey])) {
     nodesC.forEach((node) => {
       node[symbols.nodeLabelSym] = node[nodeLabelParams.dataKey] || null;
-      node[symbols.nodeUrlSym] = node[nodeLabelParams.url] || null;
+      node[symbols.nodeUrlSym] = node[nodeLabelParams.urlKey] || null;
     });
   }
 

--- a/stanzas/breadcrumbs/components/Breadcrumbs.js
+++ b/stanzas/breadcrumbs/components/Breadcrumbs.js
@@ -4,6 +4,18 @@ import { applyConstructor } from "@/lib/utils";
 import { ref, createRef } from "lit/directives/ref.js";
 
 export class Breadcrumbs extends LitElement {
+  data = [];
+  loading = false;
+  pathToShow = [];
+  nodesMap = new Map();
+  currentMenuItems = [];
+  hoverNodeId = "";
+  rootNodeId = null;
+  pathToCopy = "/";
+  observedStyle = null;
+  observer = null;
+  invisibleNode = createRef();
+
   static get properties() {
     return {
       currentId: { type: String, reflect: true },
@@ -12,22 +24,7 @@ export class Breadcrumbs extends LitElement {
   }
   constructor(element) {
     super();
-
     element.append(this);
-
-    this.data = [];
-    this.loading = false;
-    this.pathToShow = [];
-    this.nodesMap = new Map();
-    this.currentMenuItems = [];
-    this.hoverNodeId = "";
-
-    this.rootNodeId = null;
-    this.pathToCopy = "/";
-    this.observedStyle = null;
-    this.observer = null;
-
-    this.invisibleNode = createRef();
   }
 
   updateParams(params, data) {
@@ -187,6 +184,7 @@ export class Breadcrumbs extends LitElement {
       ${map(this.pathToShow, (node) => {
         return html`
           <breadcrumbs-node
+            @node-hover=${this._handleNodeHover}
             @click=${() => {
               this.currentId = "" + node[this.nodeKey];
               this.dispatchEvent(
@@ -197,13 +195,13 @@ export class Breadcrumbs extends LitElement {
                 })
               );
             }}
-            @node-hover=${this._handleNodeHover}
             @menu-item-clicked=${({ detail }) =>
               (this.currentId = "" + detail.id)}
             data-id="${node[this.nodeKey]}"
             .node="${{
               label: node[this.nodeLabelKey],
               id: node[this.nodeKey],
+              url: node[this.nodeUrlKey],
             }}"
             .menuItems=${this._getByParent(node.parent)
               .filter((d) => d[this.nodeKey] !== node[this.nodeKey])

--- a/stanzas/breadcrumbs/components/BreadcrumbsNode.js
+++ b/stanzas/breadcrumbs/components/BreadcrumbsNode.js
@@ -204,9 +204,10 @@ class Node extends LitElement {
     </g>`
         : nothing
     }
-    <text class="node-label" transform="translate(${this.textMargin.left},${
-      this.height / 2
-    })">${this.node.label}</text>
+    ${svg`<text class="node-label" transform="translate(${
+      this.textMargin.left
+    },${this.height / 2})">${this.node.label}</text>`}
+
   </g>`;
 
     return html`
@@ -218,7 +219,9 @@ class Node extends LitElement {
         height="${this.height}"
         ${ref(this.svg)}
       >
-        ${nodeG}
+        ${this.node.url
+          ? svg`<a href="${this.node.url}" target="_blank">${nodeG}</a>`
+          : nodeG}
       </svg>
 
       ${this.showMenu && this.showDropdown && this.menuItems.length > 0

--- a/stanzas/breadcrumbs/metadata.json
+++ b/stanzas/breadcrumbs/metadata.json
@@ -10,23 +10,38 @@
   "stanza:license": "MIT",
   "stanza:author": "DBCLS",
   "stanza:address": "https://github.com/togostanza/metastanza",
-  "stanza:contributor": ["PENQE", "Enishi Tech"],
+  "stanza:contributor": [
+    "PENQE",
+    "Enishi Tech"
+  ],
   "stanza:created": "2022-04-07",
   "stanza:updated": "2022-04-07",
   "stanza:parameter": [
     {
       "stanza:key": "data-url",
-      "stanza:example": "https://raw.githubusercontent.com/togostanza/togostanza-data/main/samples/json/tree-data.json",
+      "stanza:example": "https://raw.githubusercontent.com/togostanza/togostanza-data/refs/heads/feature/add-urls/samples/json/tree-data.json",
       "stanza:description": "Data source URL",
       "stanza:required": true
     },
     {
       "stanza:key": "data-type",
       "stanza:type": "single-choice",
-      "stanza:choice": ["json", "tsv", "csv", "sparql-results-json"],
+      "stanza:choice": [
+        "json",
+        "tsv",
+        "csv",
+        "sparql-results-json"
+      ],
       "stanza:example": "json",
       "stanza:description": "Data type",
       "stanza:required": true
+    },
+    {
+      "stanza:key": "node-url_key",
+      "stanza:type": "string",
+      "stanza:description": "Key of node URL",
+      "stanza:example": "url",
+      "stanza:required": false
     },
     {
       "stanza:key": "node-key",
@@ -121,7 +136,6 @@
       "stanza:description": "Background color"
     }
   ],
-
   "stanza:incomingEvent": [
     {
       "stanza:key": "selectedDatumChanged",

--- a/stanzas/breadcrumbs/style.scss
+++ b/stanzas/breadcrumbs/style.scss
@@ -30,6 +30,10 @@ breadcrumbs-el {
         font-size: calc(var(--togostanza-fonts-font_size_primary));
       }
 
+      a > .node-label:hover {
+        text-decoration: underline;
+      }
+
       .node-label,
       .home-icon {
         fill: var(--togostanza-fonts-font_color);

--- a/stanzas/breadcrumbs/style.scss
+++ b/stanzas/breadcrumbs/style.scss
@@ -30,7 +30,7 @@ breadcrumbs-el {
         font-size: calc(var(--togostanza-fonts-font_size_primary));
       }
 
-      a > .node-label {
+      a .node-label {
         text-decoration: underline;
       }
 

--- a/stanzas/breadcrumbs/style.scss
+++ b/stanzas/breadcrumbs/style.scss
@@ -30,7 +30,7 @@ breadcrumbs-el {
         font-size: calc(var(--togostanza-fonts-font_size_primary));
       }
 
-      a > .node-label:hover {
+      a > .node-label {
         text-decoration: underline;
       }
 

--- a/stanzas/breadcrumbs/style.scss
+++ b/stanzas/breadcrumbs/style.scss
@@ -30,13 +30,13 @@ breadcrumbs-el {
         font-size: calc(var(--togostanza-fonts-font_size_primary));
       }
 
-      a .node-label {
-        text-decoration: underline;
-      }
-
       .node-label,
       .home-icon {
         fill: var(--togostanza-fonts-font_color);
+      }
+
+      a > g > .node-label {
+        text-decoration: underline;
       }
 
       &.-hover {

--- a/stanzas/force-graph/drawForceLayout.js
+++ b/stanzas/force-graph/drawForceLayout.js
@@ -200,14 +200,25 @@ export default function (
   }
 
   if (nodeLabelParams.dataKey !== "" && nodes[0][nodeLabelParams.dataKey]) {
-    nodeGroups
-      .append("text")
-      .attr("x", 0)
-      .attr("dy", (d) => nodeLabelParams.margin + d[symbols.nodeSizeSym])
-      .attr("class", "label")
-      .attr("alignment-baseline", "hanging")
-      .attr("text-anchor", "middle")
-      .text((d) => d[nodeLabelParams.dataKey]);
+    nodeGroups.each(function (d) {
+      let selectionToAppend = d3.select(this);
+
+      if (d[symbols.nodeUrlSym]) {
+        selectionToAppend = selectionToAppend
+          .append("a")
+          .attr("href", d[symbols.nodeUrlSym])
+          .attr("target", "_blank");
+      }
+
+      selectionToAppend
+        .append("text")
+        .attr("x", 0)
+        .attr("dy", (d) => nodeLabelParams.margin + d[symbols.nodeSizeSym])
+        .attr("class", "label")
+        .attr("alignment-baseline", "hanging")
+        .attr("text-anchor", "middle")
+        .text(d[symbols.nodeLabelSym]);
+    });
   }
 
   let isDragging = false;

--- a/stanzas/force-graph/index.js
+++ b/stanzas/force-graph/index.js
@@ -81,7 +81,7 @@ export default class ForceGraph extends Stanza {
     const nodeLabelParams = {
       margin: 3,
       dataKey: this.params["node-label_key"],
-      url: this.params["node-url_key"],
+      urlKey: this.params["node-url_key"],
     };
 
     const highlightAdjEdges = true;

--- a/stanzas/force-graph/index.js
+++ b/stanzas/force-graph/index.js
@@ -89,9 +89,9 @@ export default class ForceGraph extends Stanza {
     const MARGIN = getMarginsFromCSSString(css("--togostanza-canvas-padding"));
 
     const graph = data.asGraph({
-      nodesKey: this.params["data-nodes_key"],
-      edgesKey: this.params["data-edges_key"],
-      nodeIdKey: this.params["node-id_key"],
+      nodesKey: this.params["data-nodes_key"] || "nodes",
+      edgesKey: this.params["data-edges_key"] || "links",
+      nodeIdKey: this.params["node-id_key"] || "id",
     });
 
     const { nodes, edges } = graph;

--- a/stanzas/force-graph/index.js
+++ b/stanzas/force-graph/index.js
@@ -53,11 +53,6 @@ export default class ForceGraph extends Stanza {
     });
 
     this._data = data.data;
-    const graph = data.asGraph({
-      edgesKey: "links", // TODO parameterize
-    });
-
-    const { nodes, edges } = graph;
 
     const nodeSizeParams = {
       dataKey: this.params["node-size_key"] || "",
@@ -86,11 +81,30 @@ export default class ForceGraph extends Stanza {
     const nodeLabelParams = {
       margin: 3,
       dataKey: this.params["node-label_key"],
+      url: this.params["node-url_key"],
     };
 
     const highlightAdjEdges = true;
 
     const MARGIN = getMarginsFromCSSString(css("--togostanza-canvas-padding"));
+
+    const graph = data.asGraph({
+      nodesKey: this.params["data-nodes_key"],
+      edgesKey: this.params["data-edges_key"],
+      nodeIdKey: this.params["node-id_key"],
+    });
+
+    const { nodes, edges } = graph;
+
+    // add any other arbitrary data that was in the json:
+    for (const node of nodes) {
+      Object.assign(
+        node,
+        this._data[this.params["data-nodes_key"]]?.find(
+          (d) => d[this.params["node-id_key"]] === node.id
+        )
+      );
+    }
 
     const tooltipParams = {
       dataKey: this.params["node-tooltip_key"],

--- a/stanzas/force-graph/metadata.json
+++ b/stanzas/force-graph/metadata.json
@@ -8,29 +8,61 @@
   "stanza:license": "MIT",
   "stanza:author": "DBCLS",
   "stanza:address": "https://github.com/togostanza/metastanza",
-  "stanza:contributor": ["PENQE", "Einishi Tech"],
+  "stanza:contributor": [
+    "PENQE",
+    "Einishi Tech"
+  ],
   "stanza:created": "2022-03-28",
   "stanza:updated": "2022-10-21",
   "stanza:parameter": [
     {
       "stanza:key": "data-url",
-      "stanza:example": "https://gist.githubusercontent.com/abkunal/98d35b9b235312e90f3e43c9f7b6932b/raw/d5589ddd53731ae8eec7abd091320df91cdcf5cd/miserables.json",
+      "stanza:example": "https://raw.githubusercontent.com/togostanza/togostanza-data/refs/heads/feature/add-urls/samples/json/graph-data.json",
       "stanza:description": "Data source URL",
       "stanza:required": true
     },
     {
       "stanza:key": "data-type",
       "stanza:type": "single-choice",
-      "stanza:choice": ["json", "tsv", "csv", "sparql-results-json"],
+      "stanza:choice": [
+        "json",
+        "tsv",
+        "csv",
+        "sparql-results-json"
+      ],
       "stanza:example": "json",
       "stanza:description": "Data type",
       "stanza:required": true
+    },
+    {
+      "stanza:key": "data-nodes_key",
+      "stanza:type": "string",
+      "stanza:example": "nodes",
+      "stanza:description": "Data key for nodes. If empty `nodes` will be used"
+    },
+    {
+      "stanza:key": "data-edges_key",
+      "stanza:type": "string",
+      "stanza:example": "links",
+      "stanza:description": "Data key for edges. If empty `links` will be used"
     },
     {
       "stanza:key": "node-size_key",
       "stanza:type": "string",
       "stanza:example": "",
       "stanza:description": "Set size on the node based on data key, or fallback to value of node-size-min"
+    },
+    {
+      "stanza:key": "node-id_key",
+      "stanza:type": "string",
+      "stanza:example": "id",
+      "stanza:description": "Set ID on the node based on data key. If empty, `id` will be used"
+    },
+    {
+      "stanza:key": "node-url_key",
+      "stanza:type": "string",
+      "stanza:example": "url",
+      "stanza:description": "Set URL on the node based on data key"
     },
     {
       "stanza:key": "node-size_min",
@@ -47,7 +79,11 @@
     {
       "stanza:key": "node-size_scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "square root", "log10"],
+      "stanza:choice": [
+        "linear",
+        "square root",
+        "log10"
+      ],
       "stanza:example": "square root",
       "stanza:description": "Node radius scale"
     },
@@ -63,7 +99,6 @@
       "stanza:example": "value",
       "stanza:description": "Set width of the edge  data key"
     },
-
     {
       "stanza:key": "edge-width_min",
       "stanza:type": "number",
@@ -79,7 +114,11 @@
     {
       "stanza:key": "edge-width_scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "square root", "log10"],
+      "stanza:choice": [
+        "linear",
+        "square root",
+        "log10"
+      ],
       "stanza:example": "linear",
       "stanza:description": "Edge width scale"
     },

--- a/stanzas/force-graph/style.scss
+++ b/stanzas/force-graph/style.scss
@@ -26,6 +26,10 @@ svg > defs > marker > path {
   cursor: pointer;
 }
 
+.node-group > a {
+  text-decoration: underline;
+}
+
 .link {
   stroke-opacity: var(--togostanza-edge-opacity);
   stroke-linecap: round;

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -8,29 +8,61 @@
   "stanza:license": "MIT",
   "stanza:author": "DBCLS",
   "stanza:address": "https://github.com/togostanza/metastanza",
-  "stanza:contributor": ["PENQE", "Einishi Tech"],
+  "stanza:contributor": [
+    "PENQE",
+    "Einishi Tech"
+  ],
   "stanza:created": "2022-04-01",
   "stanza:updated": "2022-11-02",
   "stanza:parameter": [
     {
       "stanza:key": "data-url",
-      "stanza:example": "https://gist.githubusercontent.com/abkunal/98d35b9b235312e90f3e43c9f7b6932b/raw/d5589ddd53731ae8eec7abd091320df91cdcf5cd/miserables.json",
+      "stanza:example": "https://raw.githubusercontent.com/togostanza/togostanza-data/refs/heads/feature/add-urls/samples/json/graph-data.json",
       "stanza:description": "Data source URL",
       "stanza:required": true
     },
     {
       "stanza:key": "data-type",
       "stanza:type": "single-choice",
-      "stanza:choice": ["json", "tsv", "csv", "sparql-results-json"],
+      "stanza:choice": [
+        "json",
+        "tsv",
+        "csv",
+        "sparql-results-json"
+      ],
       "stanza:example": "json",
       "stanza:description": "Data type",
       "stanza:required": true
+    },
+    {
+      "stanza:key": "data-nodes_key",
+      "stanza:type": "string",
+      "stanza:example": "nodes",
+      "stanza:description": "Data key for nodes. If empty `nodes` will be used"
+    },
+    {
+      "stanza:key": "data-edges_key",
+      "stanza:type": "string",
+      "stanza:example": "links",
+      "stanza:description": "Data key for edges. If empty `links` will be used"
     },
     {
       "stanza:key": "data-directed_graph",
       "stanza:type": "boolean",
       "stanza:example": "true",
       "stanza:description": "Whether the graph data is directed (whether to show the arrows or not)"
+    },
+    {
+      "stanza:key": "node-id_key",
+      "stanza:type": "string",
+      "stanza:example": "id",
+      "stanza:description": "Set ID on the node based on data key. If empty, `id` will be used"
+    },
+    {
+      "stanza:key": "node-url_key",
+      "stanza:type": "string",
+      "stanza:example": "url",
+      "stanza:description": "Set URL on the node based on data key"
     },
     {
       "stanza:key": "node-label_key",
@@ -47,7 +79,10 @@
     {
       "stanza:key": "nodes-sort-order",
       "stanza:type": "single-choice",
-      "stanza:choice": ["ascending", "descending"],
+      "stanza:choice": [
+        "ascending",
+        "descending"
+      ],
       "stanza:example": "ascending",
       "stanza:description": "Nodes sorting order"
     },
@@ -72,7 +107,11 @@
     {
       "stanza:key": "node-size-scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "sqrt", "log10"],
+      "stanza:choice": [
+        "linear",
+        "sqrt",
+        "log10"
+      ],
       "stanza:example": "sqrt",
       "stanza:description": "Node size scale"
     },
@@ -103,7 +142,11 @@
     {
       "stanza:key": "edge-width-scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "sqrt", "log10"],
+      "stanza:choice": [
+        "linear",
+        "sqrt",
+        "log10"
+      ],
       "stanza:example": "linear",
       "stanza:description": "Edge width scale"
     },

--- a/stanzas/layered-graph/style.scss
+++ b/stanzas/layered-graph/style.scss
@@ -27,6 +27,11 @@ g.node-g {
     stroke: var(--togostanza-border-color);
     cursor: pointer;
   }
+
+  & > a > .node-label {
+    text-decoration: underline;
+  }
+
   &.active {
     > .node-label {
       opacity: 1;

--- a/stanzas/scatter-plot/index.ts
+++ b/stanzas/scatter-plot/index.ts
@@ -22,6 +22,15 @@ type MarginsT = {
   BOTTOM: number;
 };
 
+
+const colorSym = Symbol("color");
+const sizeSym = Symbol("size");
+const idSym = Symbol("id");
+const xSym = Symbol("x");
+const ySym = Symbol("y");
+const tooltipSym = Symbol("tooltip");
+const nodeUrlSym = Symbol("nodeUrl");
+
 export default class ScatterPlot extends Stanza {
   _data: any[];
   xAxis: Axis;
@@ -79,16 +88,12 @@ export default class ScatterPlot extends Stanza {
     const showLegend = this.params["legend-visible"];
     const legendTitle = this.params["legend-title"];
     const tooltipKey = this.params["tooltips-key"];
+    const nodeUrlKey = this.params["node-url_key"]
 
     const width = parseInt(css("--togostanza-canvas-width"));
     const height = parseInt(css("--togostanza-canvas-height"));
 
-    const colorSym = Symbol("color");
-    const sizeSym = Symbol("size");
-    const idSym = Symbol("id");
-    const xSym = Symbol("x");
-    const ySym = Symbol("y");
-    const tooltipSym = Symbol("tooltip");
+
 
     const nodeSizes = extent<number, number>(
       data,
@@ -206,6 +211,7 @@ export default class ScatterPlot extends Stanza {
       datum[ySym] = this.yAxis.scale(parseFloat(datum[yKey]));
       datum[colorSym] = stanzaColors[0];
       datum[tooltipSym] = datum[tooltipKey];
+      datum[nodeUrlSym] = datum[nodeUrlKey];
     });
 
     if (showLegend) {
@@ -240,6 +246,10 @@ export default class ScatterPlot extends Stanza {
 
     const enteredCircles = circlesUpdate
       .enter()
+      .append("a")
+      .attr("href", (d) => d[nodeUrlSym])
+      .attr("target", "_blank")
+      .attr("rel", "noopener noreferrer")
       .append("circle")
       .attr("class", "chart-node")
       .attr("data-tooltip", (d) => d[tooltipSym])

--- a/stanzas/scatter-plot/metadata.json
+++ b/stanzas/scatter-plot/metadata.json
@@ -14,14 +14,19 @@
     {
       "stanza:key": "data-url",
       "stanza:type": "text",
-      "stanza:example": "https://sparql-support.dbcls.jp/sparqlist/api/metastanza_scatterplot.json",
+      "stanza:example": "https://raw.githubusercontent.com/togostanza/togostanza-data/refs/heads/feature/add-urls/samples/json/scatter-plot.json",
       "stanza:description": "Data source URL",
       "stanza:required": true
     },
     {
       "stanza:key": "data-type",
       "stanza:type": "single-choice",
-      "stanza:choice": ["json", "tsv", "csv", "sparql-results-json"],
+      "stanza:choice": [
+        "json",
+        "tsv",
+        "csv",
+        "sparql-results-json"
+      ],
       "stanza:example": "json",
       "stanza:description": "Data type",
       "stanza:required": true
@@ -68,7 +73,12 @@
     {
       "stanza:key": "axis-x-scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "log10", "ordinal", "time"],
+      "stanza:choice": [
+        "linear",
+        "log10",
+        "ordinal",
+        "time"
+      ],
       "stanza:example": "linear",
       "stanza:description": "Axis scale",
       "stanza:required": false
@@ -106,7 +116,6 @@
       "stanza:description": "Axis ticks format, in d3.format or d3.timeFormat string form (time scale). In case of time scale, use d3.timeFormat format string (https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html), fallback value for time scale is '%b %d %I %p'. Have no effect in case of ordinal scale)",
       "stanza:required": false
     },
-
     {
       "stanza:key": "axis-x-gridlines_interval",
       "stanza:type": "number",
@@ -167,7 +176,10 @@
     {
       "stanza:key": "axis-y-scale",
       "stanza:type": "single-choice",
-      "stanza:choice": ["linear", "log10"],
+      "stanza:choice": [
+        "linear",
+        "log10"
+      ],
       "stanza:example": "linear",
       "stanza:default": "linear",
       "stanza:description": "Axis scale",
@@ -195,6 +207,13 @@
       "stanza:example": null,
       "stanza:computed": true,
       "stanza:description": "Axis gridlines interval. If not set, show 5 gridlines at `neat` values, if set to 0, not show gridlines.",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "node-url_key",
+      "stanza:type": "string",
+      "stanza:example": "url",
+      "stanza:description": "Set URL on the node based on data key",
       "stanza:required": false
     },
     {


### PR DESCRIPTION
ノードURL対応を追加しました:
- ForceGraph
![image](https://github.com/user-attachments/assets/39d2b8f2-41c2-4f5f-b73a-48f53cba0c04)

- LayeredGraph
![image](https://github.com/user-attachments/assets/833136b1-3abc-4e29-ba20-7d67a3d06c7c)

- Breadcrumbs
![image](https://github.com/user-attachments/assets/7ebc3b83-e7e1-48f3-8185-a8e40c2be998)
- Scatterplot


URL のキーのマッピングは、`node-url_key`で行うようにしました。

URLがあるノードのテキストをアンダーラインで表示するようにしました。
