### PR TITLE
layered-graph: Add option for HTML in Node tooltip

### DIFF
--- a/lib/ToolTip.js
+++ b/lib/ToolTip.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { ref, createRef } from "lit/directives/ref.js";
 
 function isInNodeList(nodeList, node) {
@@ -20,7 +21,7 @@ export default class ToolTip extends LitElement {
     this.nodes = [];
     this.showing = false;
     this.tooltipContent = "";
-    this.tooltipHTML = (content) => html`${content}`;
+    this.tooltipHTML = (content) => unsafeHTML(`${content}`);
     this.mouseEL = (e) => {
       if (isInNodeList(this.nodes, e.relatedTarget)) {
         // show tooltip
@@ -66,7 +67,6 @@ export default class ToolTip extends LitElement {
         filter: drop-shadow(0 0.5px 1px black);
         color: var(--togostanza-fonts-font_color);
         font-size: calc(var(--togostanza-fonts-font_size_secondary) * 1px);
-        line-height: 1.5;
         transform: translate(-50%, -100%);
         border-radius: 10px;
         opacity: 0;
@@ -90,7 +90,7 @@ export default class ToolTip extends LitElement {
       .tooltip.-show {
         opacity: 1;
         visibility: visible;
-        height: 1.5em;
+        height: auto;
         transition: height 0ms 0ms linear, opacity 200ms 0ms linear, left 200ms,
           top 200ms;
       }
@@ -99,10 +99,10 @@ export default class ToolTip extends LitElement {
 
   render() {
     return html`
-      <div class="origin" ${ref(this.origin)}></div>
-      <div class="tooltip  ${this.showing ? "-show" : ""}" ${ref(this.tooltip)}>
+      <div class="tooltip ${this.showing ? "-show" : ""}" ${ref(this.tooltip)}>
         ${this.tooltipContent}
       </div>
+      <div class="origin" ${ref(this.origin)}></div>
     `;
   }
 

--- a/stanzas/layered-graph/index.js
+++ b/stanzas/layered-graph/index.js
@@ -136,6 +136,7 @@ export default class ForceGraph extends Stanza {
 
     const tooltipParams = {
       dataKey: this.params["tooltips-key"],
+      tooltipsHtml: this.params["tooltips-html"],
       show: nodes.some((d) => d[this.params["tooltips-key"]]),
     };
 
@@ -702,6 +703,7 @@ export default class ForceGraph extends Stanza {
       points.attr("data-tooltip", (d) => {
         return d[tooltipParams.dataKey];
       });
+      points.attr("data-tooltip-html", tooltipParams.tooltipsHtml);
       this.tooltip.setup(el.querySelectorAll("[data-tooltip]"));
     }
   }

--- a/stanzas/layered-graph/metadata.json
+++ b/stanzas/layered-graph/metadata.json
@@ -114,6 +114,12 @@
       "stanza:description": "Node tooltips data key. If empty, no tooltips will be shown"
     },
     {
+      "stanza:key": "tooltips-html",
+      "stanza:type": "boolean",
+      "stanza:example": "true",
+      "stanza:description": "Rendering HTML in Node tooltips. If empty, raw HTML will be shown"
+    },
+    {
       "stanza:key": "togostanza-custom_css_url",
       "stanza:example": "",
       "stanza:description": "Stylesheet(scss file) URL to override current style",


### PR DESCRIPTION
To show multi-modal data (e.g., Image) as HTML.

Hight properties are removed to show multi-line HTML.

Please note that we must use the `unsafeHTML` directive to display data from an untrusted source.