### PR TITLE
Treemap paramsのfix

### DIFF
--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -114,6 +114,12 @@ export default class TreeMapStanza extends MetaStanza {
   }
 }
 
+/**
+ *
+ * @param {boolean} logScale - Whether to use log10 scle or not
+ * @param {number} value - value to transform
+ * @returns
+ */
 function transformValue(logScale, value) {
   if (!value || value <= 0) {
     return null;

--- a/stanzas/treemap/index.js
+++ b/stanzas/treemap/index.js
@@ -295,10 +295,19 @@ function draw(el, dataset, opts, stanza) {
       .attr("stroke-width", 1)
       .attr("stroke", (d) => {
         const colorKey = stanza.params["node-color_key"]?.trim();
-        const baseColor =
-          colorKey && d.parent.data.data[colorKey]
-            ? d.parent.data.data[colorKey]
-            : stanza.css(colorScale(d.parent.data.data.label));
+        let baseColor;
+        if (colorKey && d.parent.data.data[colorKey]) {
+          // Use custom color from data directly
+          baseColor = d.parent.data.data[colorKey];
+        } else {
+          // Get the CSS variable string and extract just the variable name inside var()
+          const cssVariable = colorScale(d.parent.data.data.label);
+          const varName = cssVariable.substring(
+            cssVariable.indexOf("(") + 1,
+            cssVariable.lastIndexOf(")")
+          );
+          baseColor = stanza.css(varName);
+        }
         return shadeColor(baseColor, -15);
       });
 

--- a/stanzas/treemap/metadata.json
+++ b/stanzas/treemap/metadata.json
@@ -44,11 +44,10 @@
       "stanza:required": true
     },
     {
-      "stanza:key": "node-log_scale",
-      "stanza:type": "boolean",
-      "stanza:label": "Log scale for values",
-      "stanza:example": true,
-      "stanza:description": "Log scale for values"
+      "stanza:key": "node-color_key",
+      "stanza:type": "text",
+      "stanza:example": "color",
+      "stanza:description": "Set color of the node based on data key"
     },
     {
       "stanza:key": "togostanza-custom_css_url",


### PR DESCRIPTION
- `node-log_scale` 削除
- `node-color_key`追加
- 子のノードのrect のstroke の色のバグを修正